### PR TITLE
Remove unnecessary depedency redux devtools extension

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,25 +1,25 @@
 {
   "dnd.js": {
-    "bundled": 365477,
-    "minified": 133779,
-    "gzipped": 39990
+    "bundled": 358647,
+    "minified": 130745,
+    "gzipped": 38971
   },
   "dnd.min.js": {
-    "bundled": 310442,
-    "minified": 110474,
-    "gzipped": 32063
+    "bundled": 305615,
+    "minified": 108477,
+    "gzipped": 31458
   },
   "dnd.esm.js": {
-    "bundled": 241538,
-    "minified": 125427,
-    "gzipped": 32648,
+    "bundled": 241717,
+    "minified": 125554,
+    "gzipped": 32699,
     "treeshaked": {
       "rollup": {
-        "code": 21091,
-        "import_statements": 594
+        "code": 21058,
+        "import_statements": 561
       },
       "webpack": {
-        "code": 24325
+        "code": 24256
       }
     }
   }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dnd.js": {
-    "bundled": 358647,
-    "minified": 130745,
-    "gzipped": 38971
+    "bundled": 358502,
+    "minified": 130741,
+    "gzipped": 38966
   },
   "dnd.min.js": {
     "bundled": 305615,
@@ -10,9 +10,9 @@
     "gzipped": 31458
   },
   "dnd.esm.js": {
-    "bundled": 241717,
-    "minified": 125554,
-    "gzipped": 32699,
+    "bundled": 241578,
+    "minified": 125466,
+    "gzipped": 32665,
     "treeshaked": {
       "rollup": {
         "code": 21058,

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "raf-schd": "^4.0.2",
     "react-redux": "^7.2.0",
     "redux": "^4.0.4",
-    "redux-devtools-extension": "^2.13.9",
     "use-memo-one": "^1.1.2"
   },
   "devDependencies": {

--- a/src/state/create-store.ts
+++ b/src/state/create-store.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-underscore-dangle */
-import { applyMiddleware, createStore, compose } from 'redux';
+import { applyMiddleware, createStore, compose, StoreEnhancer } from 'redux';
 import reducer from './reducer';
 import lift from './middleware/lift';
 import style from './middleware/style';
@@ -19,28 +19,28 @@ import type { AutoScroller } from './auto-scroller/auto-scroller-types';
 import type { Responders, Announce } from '../types';
 import type { Store } from './store-types';
 
-// See: https://github.com/zalmoxisus/redux-devtools-extension/blob/master/npm-package/index.d.ts#L3
-interface EnhancerOptions {
+// For more config
+// See: https://github.com/reduxjs/redux-devtools/blob/main/packages/redux-devtools-extension/src/index.ts#L3
+interface Config {
   name?: string;
 }
 
-interface WindowWithDevTools extends Window {
-  __REDUX_DEVTOOLS_EXTENSION_COMPOSE__: (
-    options: EnhancerOptions,
-  ) => typeof compose;
+export interface ReduxDevtoolsExtensionCompose {
+  (config: Config): (...funcs: StoreEnhancer[]) => StoreEnhancer;
+  (...funcs: StoreEnhancer[]): StoreEnhancer;
 }
 
-const isReduxDevtoolsExtenstionExist = (
-  arg: Window | WindowWithDevTools,
-): arg is WindowWithDevTools => {
-  return '__REDUX_DEVTOOLS_EXTENSION_COMPOSE__' in arg;
-};
+declare global {
+  interface Window {
+    __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?: ReduxDevtoolsExtensionCompose;
+  }
+}
 
-// See: https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/Recipes.md#using-in-a-typescript-project
+// See: https://github.com/reduxjs/redux-devtools/blob/main/packages/redux-devtools-extension/src/index.ts#L219-L222
 const composeEnhancers =
   process.env.NODE_ENV !== 'production' &&
   typeof window !== 'undefined' &&
-  isReduxDevtoolsExtenstionExist(window)
+  window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
     ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
         name: '@react-forked/dnd',
       })

--- a/src/state/create-store.ts
+++ b/src/state/create-store.ts
@@ -24,11 +24,11 @@ interface EnhancerOptions {
   name?: string;
 }
 
-type WindowWithDevTools = Window & {
+interface WindowWithDevTools extends Window {
   __REDUX_DEVTOOLS_EXTENSION_COMPOSE__: (
     options: EnhancerOptions,
   ) => typeof compose;
-};
+}
 
 const isReduxDevtoolsExtenstionExist = (
   arg: Window | WindowWithDevTools,

--- a/src/state/create-store.ts
+++ b/src/state/create-store.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-underscore-dangle */
 import { applyMiddleware, createStore, compose } from 'redux';
-import { composeWithDevTools } from 'redux-devtools-extension';
 import reducer from './reducer';
 import lift from './middleware/lift';
 import style from './middleware/style';
@@ -20,10 +19,29 @@ import type { AutoScroller } from './auto-scroller/auto-scroller-types';
 import type { Responders, Announce } from '../types';
 import type { Store } from './store-types';
 
+// See: https://github.com/zalmoxisus/redux-devtools-extension/blob/master/npm-package/index.d.ts#L3
+interface EnhancerOptions {
+  name?: string;
+}
+
+type WindowWithDevTools = Window & {
+  __REDUX_DEVTOOLS_EXTENSION_COMPOSE__: (
+    options: EnhancerOptions,
+  ) => typeof compose;
+};
+
+const isReduxDevtoolsExtenstionExist = (
+  arg: Window | WindowWithDevTools,
+): arg is WindowWithDevTools => {
+  return '__REDUX_DEVTOOLS_EXTENSION_COMPOSE__' in arg;
+};
+
+// See: https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/Recipes.md#using-in-a-typescript-project
 const composeEnhancers =
-  process.env.NODE_ENV !== 'production'
-    ? // Details: https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/Recipes.md#using-in-a-typescript-project
-      composeWithDevTools({
+  process.env.NODE_ENV !== 'production' &&
+  typeof window !== 'undefined' &&
+  isReduxDevtoolsExtenstionExist(window)
+    ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
         name: '@react-forked/dnd',
       })
     : compose;

--- a/yarn.lock
+++ b/yarn.lock
@@ -12437,11 +12437,6 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
-redux-devtools-extension@^2.13.9:
-  version "2.13.9"
-  resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.9.tgz#6b764e8028b507adcb75a1cae790f71e6be08ae7"
-  integrity sha512-cNJ8Q/EtjhQaZ71c8I9+BPySIBVEKssbPpskBfsXqb8HJ002A3KRVHfeRzwRo6mGPqsm7XuHTqNSNeS1Khig0A==
-
 redux@^4.0.0, redux@^4.0.4:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"


### PR DESCRIPTION
It was not necessary to have this library in our code base to save a couple of line of code.