### PR TITLE
Fix typescript types

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,18 +1,18 @@
 {
   "dnd.js": {
-    "bundled": 375186,
+    "bundled": 375180,
     "minified": 135802,
-    "gzipped": 40463
+    "gzipped": 40508
   },
   "dnd.min.js": {
-    "bundled": 306751,
+    "bundled": 306745,
     "minified": 108423,
-    "gzipped": 31279
+    "gzipped": 31332
   },
   "dnd.esm.js": {
-    "bundled": 242268,
+    "bundled": 242262,
     "minified": 126037,
-    "gzipped": 32816,
+    "gzipped": 32832,
     "treeshaked": {
       "rollup": {
         "code": 20995,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,61 @@
-// Components
+// Public types
+export type {
+  Announce,
+  BeforeCapture,
+  Direction,
+  DraggableId,
+  DraggableRubric,
+  DragStart,
+  DragUpdate,
+  DraggableLocation,
+  DroppableId,
+  DropResult,
+  Id,
+  MovementMode,
+  OnBeforeCaptureResponder,
+  OnBeforeDragStartResponder,
+  OnDragEndResponder,
+  OnDragStartResponder,
+  OnDragUpdateResponder,
+  PreDragActions,
+  ResponderProvided,
+  SensorAPI,
+  Sensor,
+  SnapDragActions,
+  TypeId,
+  TryGetLock,
+  TryGetLockOptions,
+} from './types';
 
+// DragDropContext
 export { default as DragDropContext } from './view/drag-drop-context';
-export { default as Droppable } from './view/droppable';
+export type { DragDropContextProps } from './view/drag-drop-context';
+
+// Draggable
 export { default as Draggable } from './view/draggable';
+export type {
+  DraggableChildrenFn,
+  DraggableProps,
+  DraggableProvided,
+  DraggableProvidedDraggableProps,
+  DraggableProvidedDragHandleProps,
+  DraggableStateSnapshot,
+  DraggableStyle,
+  DraggingStyle,
+  DropAnimation,
+  NotDraggingStyle,
+} from './view/draggable/draggable-types';
 
-// Default sensors
+// Droppable
+export { default as Droppable } from './view/droppable';
+export type {
+  DroppableProps,
+  DroppableProvided,
+  DroppableProvidedProps,
+  DroppableStateSnapshot,
+} from './view/droppable/droppable-types';
 
+// Sensors
 export {
   useMouseSensor,
   useTouchSensor,
@@ -13,55 +63,4 @@ export {
 } from './view/use-sensor-marshal';
 
 // Utils
-
 export { resetServerContext } from './view/drag-drop-context';
-
-// Public types
-
-export type {
-  Id,
-  TypeId,
-  DraggableId,
-  DroppableId,
-  DraggableRubric,
-  MovementMode,
-  BeforeCapture,
-  DragStart,
-  DragUpdate,
-  DropResult,
-  Direction,
-  ResponderProvided,
-  Announce,
-  DraggableLocation,
-  OnBeforeCaptureResponder,
-  OnBeforeDragStartResponder,
-  OnDragStartResponder,
-  OnDragUpdateResponder,
-  OnDragEndResponder,
-  PreDragActions,
-  SensorAPI,
-  Sensor,
-  SnapDragActions,
-  TryGetLock,
-  TryGetLockOptions,
-} from './types';
-
-// Droppable types
-export type {
-  Provided as DroppableProvided,
-  StateSnapshot as DroppableStateSnapshot,
-  DroppableProps,
-} from './view/droppable/droppable-types';
-
-// Draggable types
-export type {
-  Provided as DraggableProvided,
-  StateSnapshot as DraggableStateSnapshot,
-  DragHandleProps,
-  DropAnimation,
-  DraggableProps,
-  DraggableStyle,
-  DraggingStyle,
-  NotDraggingStyle,
-  ChildrenFn as DraggableChildrenFn,
-} from './view/draggable/draggable-types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,13 +8,14 @@ export type ContextId = Id;
 export type ElementId = Id;
 
 export type DroppableMode = 'standard' | 'virtual';
-export type DroppableDescriptor = {
+
+export interface DroppableDescriptor {
   id: DroppableId;
   type: TypeId;
   mode: DroppableMode;
-};
+}
 
-export type DraggableDescriptor = {
+export interface DraggableDescriptor {
   id: DraggableId;
   index: number;
   // Inherited from Droppable
@@ -22,17 +23,17 @@ export type DraggableDescriptor = {
   // This is technically redundant but it avoids
   // needing to look up a parent droppable just to get its type
   type: TypeId;
-};
+}
 
-export type DraggableOptions = {
+export interface DraggableOptions {
   canDragInteractiveElements: boolean;
   shouldRespectForcePress: boolean;
   isEnabled: boolean;
-};
+}
 
 export type Direction = 'horizontal' | 'vertical';
 
-export type VerticalAxis = {
+export interface VerticalAxis {
   direction: 'vertical';
   line: 'y';
   start: 'top';
@@ -42,9 +43,9 @@ export type VerticalAxis = {
   crossAxisStart: 'left';
   crossAxisEnd: 'right';
   crossAxisSize: 'width';
-};
+}
 
-export type HorizontalAxis = {
+export interface HorizontalAxis {
   direction: 'horizontal';
   line: 'x';
   start: 'left';
@@ -54,36 +55,38 @@ export type HorizontalAxis = {
   crossAxisStart: 'top';
   crossAxisEnd: 'bottom';
   crossAxisSize: 'height';
-};
+}
 
 export type Axis = VerticalAxis | HorizontalAxis;
 
-export type ScrollSize = {
+export interface ScrollSize {
   scrollHeight: number;
   scrollWidth: number;
-};
+}
 
-export type ScrollDetails = {
+export interface ScrollDifference {
+  value: Position;
+  // The actual displacement as a result of a scroll is in the opposite
+  // direction to the scroll itself. When scrolling down items are displaced
+  // upwards. This value is the negated version of the 'value'
+  displacement: Position;
+}
+
+export interface ScrollDetails {
   initial: Position;
   current: Position;
   // the maximum allowable scroll for the frame
   max: Position;
-  diff: {
-    value: Position;
-    // The actual displacement as a result of a scroll is in the opposite
-    // direction to the scroll itself. When scrolling down items are displaced
-    // upwards. This value is the negated version of the 'value'
-    displacement: Position;
-  };
-};
+  diff: ScrollDifference;
+}
 
-export type Placeholder = {
+export interface Placeholder {
   client: BoxModel;
   tagName: string;
   display: string;
-};
+}
 
-export type DraggableDimension = {
+export interface DraggableDimension {
   descriptor: DraggableDescriptor;
   // the placeholder for the draggable
   placeholder: Placeholder;
@@ -94,9 +97,9 @@ export type DraggableDimension = {
   // how much displacement the draggable causes
   // this is the size of the marginBox
   displaceBy: Position;
-};
+}
 
-export type Scrollable = {
+export interface Scrollable {
   // This is the window through which the droppable is observed
   // It does not change during a drag
   pageMarginBox: Rect;
@@ -107,9 +110,9 @@ export type Scrollable = {
   // Is controlled by the ignoreContainerClipping prop
   shouldClipSubject: boolean;
   scroll: ScrollDetails;
-};
+}
 
-export type PlaceholderInSubject = {
+export interface PlaceholderInSubject {
   // might not actually be increased by
   // placeholder if there is no required space
   increasedBy: Position | null;
@@ -117,9 +120,9 @@ export type PlaceholderInSubject = {
   // max scroll before placeholder added
   // will be null if there was no frame
   oldFrameMaxScroll: Position | null;
-};
+}
 
-export type DroppableSubject = {
+export interface DroppableSubject {
   // raw, unchanging
   page: BoxModel;
   withPlaceholder: PlaceholderInSubject | null;
@@ -130,9 +133,9 @@ export type DroppableSubject = {
   // - clipped by frame
   // The subject will be null if the hit area is completely empty
   active: Rect | null;
-};
+}
 
-export type DroppableDimension = {
+export interface DroppableDimension {
   descriptor: DroppableDescriptor;
   axis: Axis;
   isEnabled: boolean;
@@ -147,11 +150,11 @@ export type DroppableDimension = {
   frame: Scrollable | null;
   // what is visible through the frame
   subject: DroppableSubject;
-};
-export type DraggableLocation = {
+}
+export interface DraggableLocation {
   droppableId: DroppableId;
   index: number;
-};
+}
 
 export type DraggableIdMap = {
   [id in DraggableId]: true;
@@ -164,58 +167,60 @@ export type DroppableIdMap = {
 export type DraggableDimensionMap = {
   [key in DraggableId]: DraggableDimension;
 };
+
 export type DroppableDimensionMap = {
   [key in DroppableId]: DroppableDimension;
 };
 
-export type Displacement = {
+export interface Displacement {
   draggableId: DraggableId;
   shouldAnimate: boolean;
-};
+}
 
 export type DisplacementMap = {
   [key in DraggableId]: Displacement;
 };
 
-export type DisplacedBy = {
+export interface DisplacedBy {
   value: number;
   point: Position;
-};
+}
 
-export type Combine = {
+export interface Combine {
   draggableId: DraggableId;
   droppableId: DroppableId;
-};
-export type DisplacementGroups = {
+}
+
+export interface DisplacementGroups {
   all: DraggableId[];
   visible: DisplacementMap;
   invisible: DraggableIdMap;
-};
+}
 
-export type ReorderImpact = {
+export interface ReorderImpact {
   type: 'REORDER';
   destination: DraggableLocation;
-};
+}
 
-export type CombineImpact = {
+export interface CombineImpact {
   type: 'COMBINE';
   combine: Combine;
-};
+}
 
 export type ImpactLocation = ReorderImpact | CombineImpact;
 
-export type Displaced = {
+export interface Displaced {
   forwards: DisplacementGroups;
   backwards: DisplacementGroups;
-};
+}
 
-export type DragImpact = {
+export interface DragImpact {
   displaced: DisplacementGroups;
   displacedBy: DisplacedBy;
   at: ImpactLocation | null;
-};
+}
 
-export type ClientPositions = {
+export interface ClientPositions {
   // where the user initially selected
   // This point is not used to calculate the impact of a dragging item
   // It is used to calculate the offset from the initial selection point
@@ -224,61 +229,61 @@ export type ClientPositions = {
   borderBoxCenter: Position;
   // how far the item has moved from its original position
   offset: Position;
-};
+}
 
-export type PagePositions = {
+export interface PagePositions {
   selection: Position;
   borderBoxCenter: Position;
   // how much the page position has changed from the initial
   offset: Position;
-};
+}
 
 // There are two seperate modes that a drag can be in
 // FLUID: everything is done in response to highly granular input (eg mouse)
 // SNAP: items move in response to commands (eg keyboard);
 export type MovementMode = 'FLUID' | 'SNAP';
 
-export type DragPositions = {
+export interface DragPositions {
   client: ClientPositions;
   page: PagePositions;
-};
+}
 
-export type DraggableRubric = {
+export interface DraggableRubric {
   draggableId: DraggableId;
   type: TypeId;
   source: DraggableLocation;
-};
+}
 
 // Published in onBeforeCapture
 // We cannot give more information as things might change in the
 // onBeforeCapture responder!
-export type BeforeCapture = {
+export interface BeforeCapture {
   draggableId: DraggableId;
   mode: MovementMode;
-};
+}
 
 // published when a drag starts
-export type DragStart = {
+export interface DragStart extends DraggableRubric {
   mode: MovementMode;
-} & DraggableRubric;
+}
 
-export type DragUpdate = {
+export interface DragUpdate extends DragStart {
   // may not have any destination (drag to nowhere)
   destination: DraggableLocation | null;
   // populated when a draggable is dragging over another in combine mode
   combine: Combine | null;
-} & DragStart;
+}
 
 export type DropReason = 'DROP' | 'CANCEL';
 
 // published when a drag finishes
-export type DropResult = {
+export interface DropResult extends DragUpdate {
   reason: DropReason;
-} & DragUpdate;
+}
 
-export type ScrollOptions = {
+export interface ScrollOptions {
   shouldPublishImmediately: boolean;
-};
+}
 
 // using the draggable id rather than the descriptor as the descriptor
 // may change as a result of the initial flush. This means that the lift
@@ -286,49 +291,50 @@ export type ScrollOptions = {
 // confusion the request is just an id which is looked up
 // in the dimension-marshal post-flush
 // Not including droppableId as it might change in a drop flush
-export type LiftRequest = {
+export interface LiftRequest {
   draggableId: DraggableId;
   scrollOptions: ScrollOptions;
-};
+}
 
-export type Critical = {
+export interface Critical {
   draggable: DraggableDescriptor;
   droppable: DroppableDescriptor;
-};
+}
 
-export type Viewport = {
+export interface Viewport {
   // live updates with the latest values
   frame: Rect;
   scroll: ScrollDetails;
-};
+}
 
-export type LiftEffect = {
+export interface LiftEffect {
   inVirtualList: boolean;
   effected: DraggableIdMap;
   displacedBy: DisplacedBy;
-};
+}
 
-export type DimensionMap = {
+export interface DimensionMap {
   draggables: DraggableDimensionMap;
   droppables: DroppableDimensionMap;
-};
+}
 
-export type DroppablePublish = {
+export interface DroppablePublish {
   droppableId: DroppableId;
   scroll: Position;
-};
-export type Published = {
+}
+
+export interface Published {
   additions: DraggableDimension[];
   removals: DraggableId[];
   modified: DroppablePublish[];
-};
+}
 
-export type CompletedDrag = {
+export interface CompletedDrag {
   critical: Critical;
   result: DropResult;
   impact: DragImpact;
   afterCritical: LiftEffect;
-};
+}
 
 export interface IdleState {
   phase: 'IDLE';
@@ -401,58 +407,62 @@ export type Announce = (message: string) => void;
 
 export type InOutAnimationMode = 'none' | 'open' | 'close';
 
-export type ResponderProvided = {
+export interface ResponderProvided {
   announce: Announce;
-};
+}
 
-export type OnBeforeCaptureResponder = (before: BeforeCapture) => unknown;
-export type OnBeforeDragStartResponder = (start: DragStart) => unknown;
+export type OnBeforeCaptureResponder = (before: BeforeCapture) => void;
+
+export type OnBeforeDragStartResponder = (start: DragStart) => void;
+
 export type OnDragStartResponder = (
   start: DragStart,
   provided: ResponderProvided,
-) => unknown;
+) => void;
+
 export type OnDragUpdateResponder = (
   update: DragUpdate,
   provided: ResponderProvided,
-) => unknown;
+) => void;
+
 export type OnDragEndResponder = (
   result: DropResult,
   provided: ResponderProvided,
-) => unknown;
+) => void;
 
-export type Responders = {
+export interface Responders {
   onBeforeCapture?: OnBeforeCaptureResponder;
   onBeforeDragStart?: OnBeforeDragStartResponder;
   onDragStart?: OnDragStartResponder;
   onDragUpdate?: OnDragUpdateResponder;
   // always required
   onDragEnd: OnDragEndResponder;
-};
+}
 
-// ## Sensors
-export type StopDragOptions = {
+// Sensors
+export interface StopDragOptions {
   shouldBlockNextClick: boolean;
-};
+}
 
-type DragActions = {
+export interface DragActions {
   drop: (args?: StopDragOptions) => void;
   cancel: (args?: StopDragOptions) => void;
   isActive: () => boolean;
   shouldRespectForcePress: () => boolean;
-};
+}
 
-export type FluidDragActions = {
+export interface FluidDragActions extends DragActions {
   move: (clientSelection: Position) => void;
-} & DragActions;
+}
 
-export type SnapDragActions = {
+export interface SnapDragActions extends DragActions {
   moveUp: () => void;
   moveDown: () => void;
   moveRight: () => void;
   moveLeft: () => void;
-} & DragActions;
+}
 
-export type PreDragActions = {
+export interface PreDragActions {
   // discover if the lock is still active
   isActive: () => boolean;
   // whether it has been indicated if force press should be respected
@@ -462,11 +472,11 @@ export type PreDragActions = {
   snapLift: () => SnapDragActions;
   // cancel the pre drag without starting a drag. Releases the lock
   abort: () => void;
-};
+}
 
-export type TryGetLockOptions = {
+export interface TryGetLockOptions {
   sourceEvent?: Event;
-};
+}
 
 export type TryGetLock = (
   draggableId: DraggableId,
@@ -474,13 +484,13 @@ export type TryGetLock = (
   options?: TryGetLockOptions,
 ) => PreDragActions | null;
 
-export type SensorAPI = {
+export interface SensorAPI {
   tryGetLock: TryGetLock;
   canGetLock: (id: DraggableId) => boolean;
   isLockClaimed: () => boolean;
   tryReleaseLock: () => void;
   findClosestDraggableId: (event: Event) => DraggableId | null;
   findOptionsForDraggable: (id: DraggableId) => DraggableOptions | null;
-};
+}
 
 export type Sensor = (api: SensorAPI) => void;

--- a/src/view/drag-drop-context/drag-drop-context.tsx
+++ b/src/view/drag-drop-context/drag-drop-context.tsx
@@ -9,18 +9,18 @@ import useUniqueContextId, {
 } from './use-unique-context-id';
 import { reset as resetUniqueIds } from '../use-unique-id';
 
-type Props = {
+export interface DragDropContextProps extends Responders {
   // We do not technically need any children for this component
   children: ReactNode | null;
   // Read out by screen readers when focusing on a drag handle
   dragHandleUsageInstructions?: string;
+  enableDefaultSensors?: boolean | null;
   // Used for strict content security policies
   // See our [content security policy guide](/docs/guides/content-security-policy.md)
   nonce?: string;
   // See our [sensor api](/docs/sensors/sensor-api.md)
   sensors?: Sensor[];
-  enableDefaultSensors?: boolean | null;
-} & Responders;
+}
 
 // Reset any context that gets persisted across server side renders
 export function resetServerContext() {
@@ -28,7 +28,7 @@ export function resetServerContext() {
   resetUniqueIds();
 }
 
-export default function DragDropContext(props: Props) {
+export default function DragDropContext(props: DragDropContextProps) {
   const contextId: ContextId = useUniqueContextId();
   const dragHandleUsageInstructions: string =
     props.dragHandleUsageInstructions || preset.dragHandleUsageInstructions;

--- a/src/view/drag-drop-context/index.ts
+++ b/src/view/drag-drop-context/index.ts
@@ -1,1 +1,2 @@
+export type { DragDropContextProps } from './drag-drop-context';
 export { default, resetServerContext } from './drag-drop-context';

--- a/src/view/draggable/connected-draggable.ts
+++ b/src/view/draggable/connected-draggable.ts
@@ -22,12 +22,12 @@ import type {
   Combine,
 } from '../../types';
 import type {
-  PublicOwnProps,
+  DraggableProps,
   MapProps,
   OwnProps,
   DispatchProps,
   Selector,
-  StateSnapshot,
+  DraggableStateSnapshot,
   DropAnimation,
 } from './draggable-types';
 import whatIsDraggedOver from '../../state/droppable/what-is-dragged-over';
@@ -62,7 +62,7 @@ function getDraggableSelector(): TrySelect {
       draggingOver: DroppableId | null = null,
       combineWith: DraggableId | null = null,
       dropping: DropAnimation | null = null,
-    ): StateSnapshot => ({
+    ): DraggableStateSnapshot => ({
       isDragging: true,
       isClone,
       isDropAnimating: Boolean(dropping),
@@ -194,7 +194,7 @@ function getDraggableSelector(): TrySelect {
 
 function getSecondarySnapshot(
   combineTargetFor: DraggableId | null = null,
-): StateSnapshot {
+): DraggableStateSnapshot {
   return {
     isDragging: false,
     isDropAnimating: false,
@@ -388,6 +388,6 @@ const ConnectedDraggable = connect(
     areStatePropsEqual: isStrictEqual,
   },
   // FIXME: Typings are really complexe
-)(Draggable) as unknown as FunctionComponent<PublicOwnProps>;
+)(Draggable) as unknown as FunctionComponent<DraggableProps>;
 
 export default ConnectedDraggable;

--- a/src/view/draggable/draggable-api.tsx
+++ b/src/view/draggable/draggable-api.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { DraggableId } from '../../types';
-import type { PublicOwnProps, PrivateOwnProps } from './draggable-types';
+import type { DraggableProps, PrivateOwnProps } from './draggable-types';
 import ConnectedDraggable from './connected-draggable';
 import useRequiredContext from '../use-required-context';
 import DroppableContext from '../context/droppable-context';
@@ -23,7 +23,7 @@ export function PrivateDraggable(props: PrivateOwnProps) {
 }
 
 // What we give to consumers
-export function PublicDraggable(props: PublicOwnProps) {
+export function PublicDraggable(props: DraggableProps) {
   // default values for props
   const isEnabled: boolean =
     typeof props.isDragDisabled === 'boolean' ? !props.isDragDisabled : true;

--- a/src/view/draggable/draggable-types.ts
+++ b/src/view/draggable/draggable-types.ts
@@ -16,7 +16,7 @@ import type {
 } from '../../types';
 import { dropAnimationFinished } from '../../state/action-creators';
 
-export type DraggingStyle = {
+export interface DraggingStyle {
   position: 'fixed';
   top: number;
   left: number;
@@ -34,14 +34,14 @@ export type DraggingStyle = {
   // canStartDrag() will prevent drags in some cases for non primary draggable.
   // It is also a minor performance optimisation
   pointerEvents: 'none';
-};
+}
 
-export type NotDraggingStyle = {
+export interface NotDraggingStyle {
   transform?: string;
   // null: use the global animation style
   // none: skip animation (used in certain displacement situations)
   transition?: 'none';
-};
+}
 
 export type DraggableStyle = DraggingStyle | NotDraggingStyle;
 
@@ -51,7 +51,7 @@ export type ZIndexOptions = {
 };
 
 // Props that can be spread onto the element directly
-export type DraggableProps = {
+export interface DraggableProvidedDraggableProps {
   // inline style
   style?: DraggableStyle;
   // used for shared global styles
@@ -60,9 +60,9 @@ export type DraggableProps = {
   'data-rfd-draggable-id': DraggableId;
   // used to know when a transition ends
   onTransitionEnd?: TransitionEventHandler;
-};
+}
 
-export type DragHandleProps = {
+export interface DraggableProvidedDragHandleProps {
   // what draggable the handle belongs to
   'data-rfd-drag-handle-draggable-id': DraggableId;
   // What DragDropContext the drag handle is in
@@ -84,35 +84,38 @@ export type DragHandleProps = {
   // Opting out of html5 drag and drop
   draggable: boolean;
   onDragStart: DragEventHandler;
-};
+}
 
-export type Provided = {
-  draggableProps: DraggableProps;
+export interface DraggableProvided {
+  draggableProps: DraggableProvidedDraggableProps;
   // will be null if the draggable is disabled
-  dragHandleProps: DragHandleProps | null;
+  dragHandleProps: DraggableProvidedDragHandleProps | null;
   // The following props will be removed once we move to react 16
-  innerRef: (a?: HTMLElement | null) => void;
-};
+  innerRef: (element?: HTMLElement | null) => void;
+}
 
 // to easily enable patching of styles
-export type DropAnimation = {
+export interface DropAnimation {
   duration: number;
   curve: string;
   moveTo: Position;
   opacity: number | null;
   scale: number | null;
-};
+}
 
-export type StateSnapshot = {
+export interface DraggableStateSnapshot {
   isDragging: boolean;
   isDropAnimating: boolean;
   isClone: boolean;
   dropAnimation: DropAnimation | null;
   draggingOver: DroppableId | null;
+  // the id of a draggable that you are combining with
   combineWith: DraggableId | null;
+  // a combine target is being dragged over by
   combineTargetFor: DraggableId | null;
+  // What type of movement is being done: 'FLUID' or 'SNAP'
   mode: MovementMode | null;
-};
+}
 
 export type DispatchProps = {
   dropAnimationFinished: typeof dropAnimationFinished;
@@ -127,7 +130,7 @@ export type DraggingMapProps = {
   combineWith: DraggableId | null;
   dimension: DraggableDimension;
   forceShouldAnimate: boolean | null;
-  snapshot: StateSnapshot;
+  snapshot: DraggableStateSnapshot;
 };
 
 export type SecondaryMapProps = {
@@ -135,7 +138,7 @@ export type SecondaryMapProps = {
   offset: Position;
   combineTargetFor: DraggableId | null;
   shouldAnimateDisplacement: boolean;
-  snapshot: StateSnapshot;
+  snapshot: DraggableStateSnapshot;
 };
 
 export type MappedProps = DraggingMapProps | SecondaryMapProps;
@@ -148,21 +151,21 @@ export type MapProps = {
   // secondary: ?SecondaryMapProps,
 };
 
-export type ChildrenFn = (
-  c: Provided,
-  b: StateSnapshot,
-  a: DraggableRubric,
+export type DraggableChildrenFn = (
+  provided: DraggableProvided,
+  snapshot: DraggableStateSnapshot,
+  rubic: DraggableRubric,
 ) => ReactNode | null;
 
-export type PublicOwnProps = {
+export interface DraggableProps {
   draggableId: DraggableId;
   index: number;
-  children: ChildrenFn;
+  children: DraggableChildrenFn;
   // optional own props
   isDragDisabled?: boolean;
   disableInteractiveElementBlocking?: boolean;
   shouldRespectForcePress?: boolean;
-};
+}
 
 export type PrivateOwnProps = {
   isClone: boolean;
@@ -170,7 +173,7 @@ export type PrivateOwnProps = {
   isEnabled: boolean;
   canDragInteractiveElements: boolean;
   shouldRespectForcePress: boolean;
-} & PublicOwnProps;
+} & DraggableProps;
 
 export type OwnProps = PrivateOwnProps;
 

--- a/src/view/draggable/draggable.tsx
+++ b/src/view/draggable/draggable.tsx
@@ -8,9 +8,9 @@ import AppContext from '../context/app-context';
 import DroppableContext from '../context/droppable-context';
 import type {
   Props,
-  Provided,
+  DraggableProvided,
   DraggableStyle,
-  DragHandleProps,
+  DraggableProvidedDragHandleProps,
 } from './draggable-types';
 import { useValidation, useClonePropValidation } from './use-validation';
 import useRequiredContext from '../use-required-context';
@@ -93,7 +93,7 @@ const Draggable: React.FunctionComponent<Props> = (props) => {
   }
   /* eslint-enable react-hooks/rules-of-hooks */
 
-  const dragHandleProps: DragHandleProps | null = useMemo(
+  const dragHandleProps: DraggableProvidedDragHandleProps | null = useMemo(
     () =>
       isEnabled
         ? {
@@ -131,12 +131,12 @@ const Draggable: React.FunctionComponent<Props> = (props) => {
     [dropAnimationFinishedAction, mapped],
   );
 
-  const provided: Provided = useMemo(() => {
+  const provided: DraggableProvided = useMemo(() => {
     const style: DraggableStyle = getStyle(mapped);
     const onTransitionEnd =
       mapped.type === 'DRAGGING' && mapped.dropping ? onMoveEnd : undefined;
 
-    const result: Provided = {
+    const result: DraggableProvided = {
       innerRef: setRef,
       draggableProps: {
         'data-rfd-draggable-context-id': contextId,

--- a/src/view/droppable/connected-droppable.ts
+++ b/src/view/droppable/connected-droppable.ts
@@ -17,11 +17,11 @@ import type {
 import type {
   MapProps,
   InternalOwnProps,
-  PublicOwnProps,
+  DroppableProps,
   DefaultProps,
   Selector,
   DispatchProps,
-  StateSnapshot,
+  DroppableStateSnapshot,
   UseClone,
   DraggableChildrenFn,
 } from './droppable-types';
@@ -94,7 +94,7 @@ export const makeMapStateToProps = (): Selector => {
             }
           : null;
 
-        const snapshot: StateSnapshot = {
+        const snapshot: DroppableStateSnapshot = {
           isDraggingOver: isDraggingOverForConsumer,
           draggingOverWith: isDraggingOverForConsumer ? draggableId : null,
           draggingFromThisWith: draggableId,
@@ -118,7 +118,7 @@ export const makeMapStateToProps = (): Selector => {
         return idleWithAnimation;
       }
 
-      const snapshot: StateSnapshot = {
+      const snapshot: DroppableStateSnapshot = {
         isDraggingOver: isDraggingOverForConsumer,
         draggingOverWith: draggableId,
         draggingFromThisWith: null,
@@ -274,7 +274,7 @@ const ConnectedDroppable = connect(
     areStatePropsEqual: isStrictEqual,
   },
   // FIXME: Typings are really complexe
-)(Droppable) as unknown as FunctionComponent<PublicOwnProps>;
+)(Droppable) as unknown as FunctionComponent<DroppableProps>;
 
 ConnectedDroppable.defaultProps = defaultProps;
 

--- a/src/view/droppable/droppable-types.ts
+++ b/src/view/droppable/droppable-types.ts
@@ -10,22 +10,22 @@ import type {
   DraggableRubric,
   DroppableMode,
 } from '../../types';
-import type { ChildrenFn } from '../draggable/draggable-types';
+import type { DraggableChildrenFn } from '../draggable/draggable-types';
 import { updateViewportMaxScroll } from '../../state/action-creators';
 
-export type DraggableChildrenFn = ChildrenFn;
+export type { DraggableChildrenFn } from '../draggable/draggable-types';
 
-export type DroppableProps = {
+export type DroppableProvidedProps = {
   // used for shared global styles
   'data-rfd-droppable-context-id': ContextId;
   // Used to lookup. Currently not used for drag and drop lifecycle
   'data-rfd-droppable-id': DroppableId;
 };
 
-export type Provided = {
+export type DroppableProvided = {
   innerRef: (a?: HTMLElement | null) => void;
   placeholder: ReactNode | null;
-  droppableProps: DroppableProps;
+  droppableProps: DroppableProvidedProps;
 };
 
 export type UseClone = {
@@ -33,7 +33,7 @@ export type UseClone = {
   render: DraggableChildrenFn;
 };
 
-export type StateSnapshot = {
+export type DroppableStateSnapshot = {
   // Is the Droppable being dragged over?
   isDraggingOver: boolean;
   // What is the id of the draggable that is dragging over the Droppable?
@@ -53,32 +53,35 @@ export type MapProps = {
   placeholder: Placeholder | null;
   shouldAnimatePlaceholder: boolean;
   // snapshot based on redux state to be provided to consumers
-  snapshot: StateSnapshot;
+  snapshot: DroppableStateSnapshot;
   useClone: UseClone | null;
 };
 
-export type DefaultProps = {
+export interface DefaultProps {
+  direction: Direction;
+  getContainerForClone: () => HTMLElement;
+  ignoreContainerClipping: boolean;
+  isCombineEnabled: boolean;
+  isDropDisabled: boolean;
   mode: DroppableMode;
   type: TypeId;
-  isDropDisabled: boolean;
-  isCombineEnabled: boolean;
-  direction: Direction;
   renderClone: DraggableChildrenFn | null;
-  ignoreContainerClipping: boolean;
-  getContainerForClone: () => HTMLElement;
-};
+}
 
 export type DispatchProps = {
   updateViewportMaxScroll: typeof updateViewportMaxScroll;
 };
 
-export type PublicOwnProps = {
-  children: (b: Provided, a: StateSnapshot) => ReactNode;
+export interface DroppableProps extends Partial<DefaultProps> {
+  children: (
+    provided: DroppableProvided,
+    snapshot: DroppableStateSnapshot,
+  ) => ReactNode;
   droppableId: DroppableId;
   renderClone?: DraggableChildrenFn | null;
-} & Partial<DefaultProps>;
+}
 
-export type InternalOwnProps = PublicOwnProps &
+export type InternalOwnProps = DroppableProps &
   DefaultProps & {
     renderClone: DraggableChildrenFn | null;
   };

--- a/src/view/droppable/droppable.tsx
+++ b/src/view/droppable/droppable.tsx
@@ -15,8 +15,8 @@ import type { DroppableContextValue } from '../context/droppable-context';
 import getMaxWindowScroll from '../window/get-max-window-scroll';
 import useValidation from './use-validation';
 import type {
-  DraggableStateSnapshot as DraggableStateSnapshot,
-  DraggableProvided as DraggableProvided,
+  DraggableStateSnapshot,
+  DraggableProvided,
 } from '../draggable/draggable-types';
 import AnimateInOut from '../animate-in-out/animate-in-out';
 import type { AnimateProvided } from '../animate-in-out/animate-in-out';

--- a/src/view/droppable/droppable.tsx
+++ b/src/view/droppable/droppable.tsx
@@ -4,7 +4,7 @@ import React, { useRef, useContext, FunctionComponent } from 'react';
 import type { ReactNode } from 'react';
 import { invariant } from '../../invariant';
 import type { DraggableId } from '../../types';
-import type { Props, Provided } from './droppable-types';
+import type { Props, DroppableProvided } from './droppable-types';
 import useDroppablePublisher from '../use-droppable-publisher';
 import Placeholder from '../placeholder';
 import AppContext from '../context/app-context';
@@ -15,8 +15,8 @@ import type { DroppableContextValue } from '../context/droppable-context';
 import getMaxWindowScroll from '../window/get-max-window-scroll';
 import useValidation from './use-validation';
 import type {
-  StateSnapshot as DraggableStateSnapshot,
-  Provided as DraggableProvided,
+  DraggableStateSnapshot as DraggableStateSnapshot,
+  DraggableProvided as DraggableProvided,
 } from '../draggable/draggable-types';
 import AnimateInOut from '../animate-in-out/animate-in-out';
 import type { AnimateProvided } from '../animate-in-out/animate-in-out';
@@ -117,8 +117,8 @@ const Droppable: FunctionComponent<Props> = (props) => {
     ],
   );
 
-  const provided: Provided = useMemo(
-    (): Provided => ({
+  const provided: DroppableProvided = useMemo(
+    (): DroppableProvided => ({
       innerRef: setDroppableRef,
       placeholder,
 

--- a/test/unit/integration/reorder-render-sync.spec.tsx
+++ b/test/unit/integration/reorder-render-sync.spec.tsx
@@ -7,8 +7,8 @@ import type { DropResult } from '../../../src';
 import { getComputedSpacing } from '../../util/dimension';
 import * as keyCodes from '../../../src/view/key-codes';
 import { simpleLift, keyboard } from './util/controls';
-import type { Provided as DraggableProvided } from '../../../src/view/draggable/draggable-types';
-import type { Provided as DroppableProvided } from '../../../src/view/droppable/droppable-types';
+import type { DraggableProvided } from '../../../src/view/draggable/draggable-types';
+import type { DroppableProvided } from '../../../src/view/droppable/droppable-types';
 import setDOMRect from '../../util/set-dom-rect';
 
 const reorder = (list: any[], startIndex: number, endIndex: number): any[] => {

--- a/test/unit/integration/responders-integration.spec.tsx
+++ b/test/unit/integration/responders-integration.spec.tsx
@@ -20,8 +20,8 @@ import type {
   OnDragUpdateResponder,
   OnDragEndResponder,
 } from '../../../src/types';
-import type { Provided as DraggableProvided } from '../../../src/view/draggable/draggable-types';
-import type { Provided as DroppableProvided } from '../../../src/view/droppable/droppable-types';
+import type { DraggableProvided } from '../../../src/view/draggable/draggable-types';
+import type { DroppableProvided } from '../../../src/view/droppable/droppable-types';
 import { getComputedSpacing } from '../../util/dimension';
 import { simpleLift, mouse } from './util/controls';
 import setDOMRect from '../../util/set-dom-rect';

--- a/test/unit/integration/responders-timing.spec.tsx
+++ b/test/unit/integration/responders-timing.spec.tsx
@@ -5,8 +5,8 @@ import { invariant } from '../../../src/invariant';
 import { DragDropContext, Draggable, Droppable } from '../../../src';
 import { getComputedSpacing } from '../../util/dimension';
 import setDOMRect from '../../util/set-dom-rect';
-import type { Provided as DraggableProvided } from '../../../src/view/draggable/draggable-types';
-import type { Provided as DroppableProvided } from '../../../src/view/droppable/droppable-types';
+import type { DraggableProvided } from '../../../src/view/draggable/draggable-types';
+import type { DroppableProvided } from '../../../src/view/droppable/droppable-types';
 import type { Responders } from '../../../src/types';
 import { simpleLift, keyboard } from './util/controls';
 

--- a/test/unit/view/connected-draggable/child-render-behaviour.spec.tsx
+++ b/test/unit/view/connected-draggable/child-render-behaviour.spec.tsx
@@ -4,7 +4,7 @@ import { render } from '@testing-library/react';
 import { DragDropContext } from '../../../../src';
 import { getPreset } from '../../../util/dimension';
 import Draggable from '../../../../src/view/draggable/connected-draggable';
-import type { Provided } from '../../../../src/view/draggable/draggable-types';
+import type { DraggableProvided } from '../../../../src/view/draggable/draggable-types';
 import DroppableContext from '../../../../src/view/context/droppable-context';
 
 import type { DroppableContextValue } from '../../../../src/view/context/droppable-context';
@@ -19,7 +19,7 @@ const droppableContext: DroppableContextValue = {
 
 class Person extends Component<{
   name: string;
-  provided: Provided;
+  provided: DraggableProvided;
 }> {
   render() {
     const { provided, name } = this.props;
@@ -37,7 +37,7 @@ class Person extends Component<{
 
 type Props = {
   currentUser: string;
-  children: (currentUser: string, dragProvided: Provided) => ReactNode;
+  children: (currentUser: string, dragProvided: DraggableProvided) => ReactNode;
 };
 
 function App({ currentUser, children }: Props) {
@@ -53,7 +53,7 @@ function App({ currentUser, children }: Props) {
 }
 
 function getMock() {
-  return jest.fn((currentUser: string, provided: Provided) => (
+  return jest.fn((currentUser: string, provided: DraggableProvided) => (
     <Person name={currentUser} provided={provided} />
   ));
 }

--- a/test/unit/view/connected-draggable/util/get-snapshot.ts
+++ b/test/unit/view/connected-draggable/util/get-snapshot.ts
@@ -1,5 +1,5 @@
 import type {
-  StateSnapshot,
+  DraggableStateSnapshot,
   DropAnimation,
 } from '../../../../../src/view/draggable/draggable-types';
 import type {
@@ -22,7 +22,7 @@ export const getDraggingSnapshot = ({
   combineWith,
   dropping,
   isClone,
-}: GetDraggingSnapshotArgs): StateSnapshot => ({
+}: GetDraggingSnapshotArgs): DraggableStateSnapshot => ({
   isDragging: true,
   isDropAnimating: Boolean(dropping),
   dropAnimation: dropping,
@@ -39,7 +39,7 @@ type GetSecondarySnapshotArgs = {
 
 export const getSecondarySnapshot = ({
   combineTargetFor,
-}: GetSecondarySnapshotArgs): StateSnapshot => ({
+}: GetSecondarySnapshotArgs): DraggableStateSnapshot => ({
   isDragging: false,
   isClone: false,
   isDropAnimating: false,

--- a/test/unit/view/connected-droppable/child-render-behaviour.spec.tsx
+++ b/test/unit/view/connected-droppable/child-render-behaviour.spec.tsx
@@ -1,13 +1,13 @@
 import React, { Component } from 'react';
 import { mount } from 'enzyme';
-import type { Provided } from '../../../../src/view/droppable/droppable-types';
+import type { DroppableProvided } from '../../../../src/view/droppable/droppable-types';
 import Droppable from '../../../../src/view/droppable/connected-droppable';
 import forceUpdate from '../../../util/force-update';
 import { DragDropContext } from '../../../../src';
 
 class Person extends Component<{
   name: string;
-  provided: Provided;
+  provided: DroppableProvided;
 }> {
   render() {
     const { provided, name } = this.props;
@@ -26,7 +26,7 @@ class App extends Component<{
     return (
       <DragDropContext onDragEnd={() => {}}>
         <Droppable droppableId="drop-1">
-          {(provided: Provided) => (
+          {(provided: DroppableProvided) => (
             <Person name={this.props.currentUser} provided={provided} />
           )}
         </Droppable>

--- a/test/unit/view/droppable/inner-ref-validation.spec.tsx
+++ b/test/unit/view/droppable/inner-ref-validation.spec.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
-import type { Provided } from '../../../../src/view/droppable/droppable-types';
+import type { DroppableProvided } from '../../../../src/view/droppable/droppable-types';
 import mount from './util/mount';
 import { withError } from '../../../util/console';
 
 it('should warn a consumer if they have not provided a ref', () => {
   class NoRef extends React.Component<{
-    provided: Provided;
+    provided: DroppableProvided;
   }> {
     render() {
-      const provided: Provided = this.props.provided;
+      const provided: DroppableProvided = this.props.provided;
 
       return (
         <div {...provided.droppableProps}>
@@ -26,10 +26,10 @@ it('should warn a consumer if they have not provided a ref', () => {
 
 it('should throw a consumer if they have provided an SVGElement', () => {
   class WithSVG extends React.Component<{
-    provided: Provided;
+    provided: DroppableProvided;
   }> {
     render() {
-      const provided: Provided = this.props.provided;
+      const provided: DroppableProvided = this.props.provided;
 
       return (
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/test/unit/view/droppable/placeholder-setup-warning.spec.tsx
+++ b/test/unit/view/droppable/placeholder-setup-warning.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { ReactWrapper } from 'enzyme';
-import type { Provided } from '../../../../src/view/droppable/droppable-types';
+import type { DroppableProvided } from '../../../../src/view/droppable/droppable-types';
 import {
   homeAtRest,
   foreignOwnProps,
@@ -11,7 +11,7 @@ import mount from './util/mount';
 import { disableWarn } from '../../../util/console';
 
 class WithNoPlaceholder extends React.Component<{
-  provided: Provided;
+  provided: DroppableProvided;
 }> {
   render() {
     return (

--- a/test/unit/view/droppable/util/get-props.ts
+++ b/test/unit/view/droppable/util/get-props.ts
@@ -1,14 +1,14 @@
 import { getPreset } from '../../../../util/dimension';
 import type {
   MapProps,
-  PublicOwnProps,
+  DroppableProps,
   DispatchProps,
 } from '../../../../../src/view/droppable/droppable-types';
 import getBodyElement from '../../../../../src/view/get-body-element';
 
 export const preset = getPreset();
 
-export const homeOwnProps: Required<PublicOwnProps> = {
+export const homeOwnProps: Required<DroppableProps> = {
   droppableId: preset.home.descriptor.id,
   type: preset.home.descriptor.type,
   mode: preset.home.descriptor.mode,
@@ -21,7 +21,7 @@ export const homeOwnProps: Required<PublicOwnProps> = {
   renderClone: null,
 };
 
-export const foreignOwnProps: Required<PublicOwnProps> = {
+export const foreignOwnProps: Required<DroppableProps> = {
   ...homeOwnProps,
   droppableId: preset.foreign.descriptor.id,
   type: preset.foreign.descriptor.type,

--- a/test/unit/view/droppable/util/get-stubber.tsx
+++ b/test/unit/view/droppable/util/get-stubber.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import type {
-  Provided,
-  StateSnapshot,
+  DroppableStateSnapshot,
+  DroppableProvided,
 } from '../../../../../src/view/droppable/droppable-types';
 
 export default (mock = (arg: unknown) => {}) =>
   class Stubber extends React.Component<{
-    provided: Provided;
-    snapshot: StateSnapshot;
+    provided: DroppableProvided;
+    snapshot: DroppableStateSnapshot;
   }> {
     render() {
       const { provided, snapshot } = this.props;

--- a/test/unit/view/droppable/util/mount.tsx
+++ b/test/unit/view/droppable/util/mount.tsx
@@ -2,10 +2,10 @@ import React, { useMemo } from 'react';
 import { mount } from 'enzyme';
 import type {
   MapProps,
-  PublicOwnProps,
-  Provided,
+  DroppableProps,
+  DroppableProvided,
   DispatchProps,
-  StateSnapshot,
+  DroppableStateSnapshot,
   Props,
 } from '../../../../../src/view/droppable/droppable-types';
 import Droppable from '../../../../../src/view/droppable/droppable';
@@ -23,7 +23,7 @@ import useFocusMarshal from '../../../../../src/view/use-focus-marshal';
 
 type MountArgs = {
   WrappedComponent?: any;
-  ownProps?: Required<PublicOwnProps>;
+  ownProps?: Required<DroppableProps>;
   mapProps?: MapProps;
   dispatchProps?: DispatchProps;
   isMovementAllowed?: () => boolean;
@@ -55,7 +55,7 @@ function App(props: AppProps) {
   return (
     <AppContext.Provider value={context}>
       <Droppable {...rest}>
-        {(provided: Provided, snapshot: StateSnapshot) => (
+        {(provided: DroppableProvided, snapshot: DroppableStateSnapshot) => (
           <WrappedComponent provided={provided} snapshot={snapshot} />
         )}
       </Droppable>


### PR DESCRIPTION
With the `v14.0.0-alpha.5` we've introducted an issue with the typings because we were not exposing the same types as before and they did not had the same name.

Here we are making sure to keep a similar type API with what we had before :slightly_smiling_face: 