### PR TITLE
React redux v8

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,25 +1,25 @@
 {
   "dnd.js": {
-    "bundled": 375284,
-    "minified": 135837,
-    "gzipped": 40524
+    "bundled": 339379,
+    "minified": 124610,
+    "gzipped": 37183
   },
   "dnd.min.js": {
-    "bundled": 306859,
-    "minified": 108429,
-    "gzipped": 31342
+    "bundled": 301503,
+    "minified": 106872,
+    "gzipped": 30822
   },
   "dnd.esm.js": {
-    "bundled": 242252,
-    "minified": 126027,
-    "gzipped": 32831,
+    "bundled": 242224,
+    "minified": 126011,
+    "gzipped": 32827,
     "treeshaked": {
       "rollup": {
-        "code": 20995,
+        "code": 20979,
         "import_statements": 561
       },
       "webpack": {
-        "code": 24433
+        "code": 24417
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -70,8 +70,8 @@
     "css-box-model": "^1.2.1",
     "memoize-one": "^6.0.0",
     "raf-schd": "^4.0.3",
-    "react-redux": "^7.2.8",
-    "redux": "^4.1.2",
+    "react-redux": "^8.0.0",
+    "redux": "^4.2.0",
     "use-memo-one": "^1.1.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
   '@atlaskit/css-reset': 6.3.10
@@ -105,11 +105,11 @@ specifiers:
   react-16: npm:react@16.14.0
   react-dom: 17.0.2
   react-dom-16: npm:react-dom@16.14.0
-  react-redux: ^7.2.8
+  react-redux: ^8.0.0
   react-test-renderer: 17.0.2
   react-virtualized: 9.22.3
   react-window: 1.8.6
-  redux: ^4.1.2
+  redux: ^4.2.0
   release-it: 14.14.1
   require-from-string: 2.0.2
   rimraf: 3.0.2
@@ -137,15 +137,15 @@ dependencies:
   css-box-model: 1.2.1
   memoize-one: 6.0.0
   raf-schd: 4.0.3
-  react-redux: 7.2.8_react-dom@17.0.2+react@17.0.2
-  redux: 4.1.2
+  react-redux: 8.0.1_ihq5kkl6mjij4qge27qzzrokfq
+  redux: 4.2.0
   use-memo-one: 1.1.2_react@17.0.2
 
 devDependencies:
   '@atlaskit/css-reset': 6.3.10_react@17.0.2
   '@atlaskit/theme': 12.1.6_react@17.0.2
   '@babel/core': 7.17.9
-  '@babel/eslint-parser': 7.17.0_@babel+core@7.17.9+eslint@8.13.0
+  '@babel/eslint-parser': 7.17.0_oqkaaegtg3mwlb3uu272jpxkji
   '@babel/plugin-proposal-class-properties': 7.16.7_@babel+core@7.17.9
   '@babel/plugin-proposal-private-methods': 7.16.11_@babel+core@7.17.9
   '@babel/plugin-proposal-private-property-in-object': 7.16.7_@babel+core@7.17.9
@@ -160,25 +160,25 @@ devDependencies:
   '@commitlint/cz-commitlint': 16.2.3_commitizen@4.2.4
   '@emotion/babel-preset-css-prop': 11.2.0_@babel+core@7.17.9
   '@emotion/eslint-plugin': 11.7.0_eslint@8.13.0
-  '@emotion/react': 11.9.0_e6bd7585f4e0972b809c85f7a8594d19
-  '@emotion/styled': 11.8.1_690fbe9e307bc3519937bb562dc3a813
+  '@emotion/react': 11.9.0_426xlbpu4clsxae4qx32qwknde
+  '@emotion/styled': 11.8.1_neh35hrqppbvdgjxxnlc3q5icm
   '@jest/environment': 27.5.1
   '@release-it/conventional-changelog': 4.2.2_release-it@14.14.1
-  '@rollup/plugin-babel': 5.3.1_@babel+core@7.17.9+rollup@2.70.1
+  '@rollup/plugin-babel': 5.3.1_p6bgnjzmwqvrgilysw56ndqcdu
   '@rollup/plugin-commonjs': 21.0.3_rollup@2.70.1
   '@rollup/plugin-json': 4.1.0_rollup@2.70.1
   '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
   '@rollup/plugin-replace': 4.0.0_rollup@2.70.1
   '@rollup/plugin-strip': 2.1.0_rollup@2.70.1
-  '@storybook/addon-docs': 6.5.0-alpha.60_104f5a80348b342b672114276447d073
-  '@storybook/addon-essentials': 6.5.0-alpha.60_104f5a80348b342b672114276447d073
-  '@storybook/addon-storysource': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-  '@storybook/addons': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-  '@storybook/core': 6.5.0-alpha.60_4cdad558125416cc5d72dc9617822e96
-  '@storybook/react': 6.5.0-alpha.60_53061357d4abbea43324b67fa10c9322
-  '@storybook/theming': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+  '@storybook/addon-docs': 6.5.0-alpha.60_cbhvvaburm2cwzzbcqtwir6qom
+  '@storybook/addon-essentials': 6.5.0-alpha.60_cbhvvaburm2cwzzbcqtwir6qom
+  '@storybook/addon-storysource': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+  '@storybook/addons': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+  '@storybook/core': 6.5.0-alpha.60_jtnnkwaskqlmyxls3slbparosy
+  '@storybook/react': 6.5.0-alpha.60_kmdbgv6uvo7kimzewz72cdetei
+  '@storybook/theming': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
   '@testing-library/dom': 8.13.0
-  '@testing-library/react': 12.1.4_react-dom@17.0.2+react@17.0.2
+  '@testing-library/react': 12.1.4_sfoxds7t5ydpegc3knd667wn6m
   '@types/enzyme': 3.10.12
   '@types/express': 4.17.13
   '@types/fs-extra': 9.0.13
@@ -194,11 +194,11 @@ devDependencies:
   '@types/react-virtualized': 9.21.21
   '@types/react-window': 1.8.5
   '@types/seedrandom': 3.0.2
-  '@typescript-eslint/eslint-plugin': 5.18.0_0dd9be2ba5ed9805045f3fec8be848f5
-  '@typescript-eslint/parser': 5.18.0_eslint@8.13.0+typescript@4.6.3
-  '@wojtekmaj/enzyme-adapter-react-17': 0.6.7_fae758709a8810ba97b4c03852dde4d0
+  '@typescript-eslint/eslint-plugin': 5.18.0_bxm34k5f5wmakbc7h7wix2ci6u
+  '@typescript-eslint/parser': 5.18.0_jzhokl4shvj5szf5bgr66kln2a
+  '@wojtekmaj/enzyme-adapter-react-17': 0.6.7_7ltvq4e2railvf5uya4ffxpe2a
   babel-jest: 27.5.1_@babel+core@7.17.9
-  babel-loader: 8.2.4_acba72ea4bf9d339cdfcd8f55cdb7006
+  babel-loader: 8.2.4_vs5hf2sl7hjtttp43d2vzw3qay
   babel-plugin-dev-expression: 0.2.3_@babel+core@7.17.9
   babel-plugin-module-resolver: 4.1.0
   commitizen: 4.2.4
@@ -208,21 +208,21 @@ devDependencies:
   dotenv: 16.0.0
   emotion-theming: 11.0.0
   enzyme: 3.11.0
-  enzyme-adapter-react-16: 1.15.6_fae758709a8810ba97b4c03852dde4d0
+  enzyme-adapter-react-16: 1.15.6_7ltvq4e2railvf5uya4ffxpe2a
   eslint: 8.13.0
-  eslint-config-airbnb: 19.0.4_98153b3cb1eb5f851029189077e45ffc
+  eslint-config-airbnb: 19.0.4_taktwpfr5npykebjdcihpzc77q
   eslint-config-prettier: 8.5.0_eslint@8.13.0
-  eslint-import-resolver-typescript: 2.7.1_25dbcfb8cfecb7418ebda712664abe37
+  eslint-import-resolver-typescript: 2.7.1_exn47ogp5s3uddv5u4jgmsv6g4
   eslint-plugin-cypress: 2.12.1_eslint@8.13.0
   eslint-plugin-es5: 1.5.0_eslint@8.13.0
   eslint-plugin-import: 2.26.0_eslint@8.13.0
-  eslint-plugin-jest: 26.1.4_3d39dff4be9be9ebd9147828001ec409
+  eslint-plugin-jest: 26.1.4_hu4575f6tpu6xwiupauaahwebe
   eslint-plugin-jsx-a11y: 6.5.1_eslint@8.13.0
   eslint-plugin-node: 11.1.0_eslint@8.13.0
-  eslint-plugin-prettier: 4.0.0_1815ac95b7fb26c13c7d48a8eef62d0f
+  eslint-plugin-prettier: 4.0.0_dak2zfnx7mtmcpd5jcuo55rnb4
   eslint-plugin-react: 7.29.4_eslint@8.13.0
   eslint-plugin-react-hooks: 4.4.0_eslint@8.13.0
-  eslint-plugin-storybook: 0.5.8_eslint@8.13.0+typescript@4.6.3
+  eslint-plugin-storybook: 0.5.8_jzhokl4shvj5szf5bgr66kln2a
   express: 4.17.3
   fast-glob: 3.2.11
   fs-extra: 10.0.1
@@ -243,25 +243,25 @@ devDependencies:
   react-dom: 17.0.2_react@17.0.2
   react-dom-16: /react-dom/16.14.0_react@17.0.2
   react-test-renderer: 17.0.2_react@17.0.2
-  react-virtualized: 9.22.3_react-dom@17.0.2+react@17.0.2
-  react-window: 1.8.6_react-dom@17.0.2+react@17.0.2
+  react-virtualized: 9.22.3_sfoxds7t5ydpegc3knd667wn6m
+  react-window: 1.8.6_sfoxds7t5ydpegc3knd667wn6m
   release-it: 14.14.1
   require-from-string: 2.0.2
   rimraf: 3.0.2
   rollup: 2.70.1
-  rollup-plugin-dts: 4.2.1_rollup@2.70.1+typescript@4.6.3
+  rollup-plugin-dts: 4.2.1_3zpigpz7crs5s43nhxirf6uitu
   rollup-plugin-size-snapshot: 0.12.0_rollup@2.70.1
   rollup-plugin-terser: 7.0.2_rollup@2.70.1
   seedrandom: 3.0.5
-  storybook-addon-performance: 0.16.1_b49bddbe4b905ced4713cb857cca91fa
-  styled-components: 5.3.5_react-dom@17.0.2+react@17.0.2
+  storybook-addon-performance: 0.16.1_wsn53pslsboo2rytzocxzsur7i
+  styled-components: 5.3.5_sfoxds7t5ydpegc3knd667wn6m
   stylelint: 14.6.1
   stylelint-config-prettier: 9.0.3_stylelint@14.6.1
   stylelint-config-recommended: 7.0.0_stylelint@14.6.1
   stylelint-config-standard: 25.0.0_stylelint@14.6.1
   stylelint-config-styled-components: 0.1.1
   stylelint-processor-styled-components: 1.10.0
-  ts-jest: 27.1.4_e5fb0852f9419ae84240799a2f4ee178
+  ts-jest: 27.1.4_4x5qquxzignoqqsapgnc6txbpa
   typescript: 4.6.3
   wait-on: 6.0.1
   webpack: 5.72.0
@@ -395,7 +395,7 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/eslint-parser/7.17.0_@babel+core@7.17.9+eslint@8.13.0:
+  /@babel/eslint-parser/7.17.0_oqkaaegtg3mwlb3uu272jpxkji:
     resolution: {integrity: sha512-PUEJ7ZBXbRkbq3qqM/jZ2nIuakUBqCYc7Qf52Lj7dlZ6zERnqisdHioL0l4wwQZnmskMeasqUNzLBFKs3nylXA==}
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
     peerDependencies:
@@ -1997,7 +1997,7 @@ packages:
       '@types/node': 16.11.26
       chalk: 4.1.2
       cosmiconfig: 7.0.1
-      cosmiconfig-typescript-loader: 1.0.6_ddaac8e123aeb260f586984cee874848
+      cosmiconfig-typescript-loader: 1.0.6_3wvmryjdv2zgb5mgtbgo5b2ija
       lodash: 4.17.21
       resolve-from: 5.0.0
       typescript: 4.6.3
@@ -2235,7 +2235,7 @@ packages:
     resolution: {integrity: sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==}
     dev: true
 
-  /@emotion/react/11.9.0_e6bd7585f4e0972b809c85f7a8594d19:
+  /@emotion/react/11.9.0_426xlbpu4clsxae4qx32qwknde:
     resolution: {integrity: sha512-lBVSF5d0ceKtfKCDQJveNAtkC7ayxpVlgOohLgXqRwqWr9bOf4TZAFFyIcNngnV6xK6X4x2ZeXq7vliHkoVkxQ==}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -2297,7 +2297,7 @@ packages:
     resolution: {integrity: sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g==}
     dev: true
 
-  /@emotion/styled-base/10.3.0_316248eb6686a2fd4fbadcfd00de37f3:
+  /@emotion/styled-base/10.3.0_gfrer23gq2rp2t523t6qbxrx6m:
     resolution: {integrity: sha512-PBRqsVKR7QRNkmfH78hTSSwHWcwDpecH9W6heujWAcyp2wdz/64PP73s7fWS1dIPm8/Exc8JAzYS8dEWXjv60w==}
     peerDependencies:
       '@emotion/core': ^10.0.28
@@ -2311,19 +2311,19 @@ packages:
       react: 17.0.2
     dev: true
 
-  /@emotion/styled/10.3.0_316248eb6686a2fd4fbadcfd00de37f3:
+  /@emotion/styled/10.3.0_gfrer23gq2rp2t523t6qbxrx6m:
     resolution: {integrity: sha512-GgcUpXBBEU5ido+/p/mCT2/Xx+Oqmp9JzQRuC+a4lYM4i4LBBn/dWvc0rQ19N9ObA8/T4NWMrPNe79kMBDJqoQ==}
     peerDependencies:
       '@emotion/core': ^10.0.27
       react: '>=16.3.0'
     dependencies:
       '@emotion/core': 10.3.1_react@17.0.2
-      '@emotion/styled-base': 10.3.0_316248eb6686a2fd4fbadcfd00de37f3
+      '@emotion/styled-base': 10.3.0_gfrer23gq2rp2t523t6qbxrx6m
       babel-plugin-emotion: 10.2.2
       react: 17.0.2
     dev: true
 
-  /@emotion/styled/11.8.1_690fbe9e307bc3519937bb562dc3a813:
+  /@emotion/styled/11.8.1_neh35hrqppbvdgjxxnlc3q5icm:
     resolution: {integrity: sha512-OghEVAYBZMpEquHZwuelXcRjRJQOVayvbmNR0zr174NHdmMgrNkLC6TljKC5h9lZLkN5WGrdUcrKlOJ4phhoTQ==}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -2340,7 +2340,7 @@ packages:
       '@babel/runtime': 7.17.9
       '@emotion/babel-plugin': 11.7.2_@babel+core@7.17.9
       '@emotion/is-prop-valid': 1.1.2
-      '@emotion/react': 11.9.0_e6bd7585f4e0972b809c85f7a8594d19
+      '@emotion/react': 11.9.0_426xlbpu4clsxae4qx32qwknde
       '@emotion/serialize': 1.0.2
       '@emotion/utils': 1.1.0
       '@types/react': 17.0.44
@@ -2873,7 +2873,7 @@ packages:
       '@octokit/openapi-types': 11.2.0
     dev: true
 
-  /@pmmmwh/react-refresh-webpack-plugin/0.5.4_a6ddf6349bbfbae23464eb7cd0d9bae7:
+  /@pmmmwh/react-refresh-webpack-plugin/0.5.4_u3o7mne3x65oende5n6nbwn244:
     resolution: {integrity: sha512-zZbZeHQDnoTlt2AF+diQT0wsSXpvWiaIOZwBRdltNFhG1+I3ozyaw7U/nBiUwyJ0D+zwdXp0E3bWOl38Ag2BMw==}
     engines: {node: '>= 10.13'}
     peerDependencies:
@@ -2929,7 +2929,7 @@ packages:
       release-it: 14.14.1
     dev: true
 
-  /@rollup/plugin-babel/5.3.1_@babel+core@7.17.9+rollup@2.70.1:
+  /@rollup/plugin-babel/5.3.1_p6bgnjzmwqvrgilysw56ndqcdu:
     resolution: {integrity: sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
@@ -3123,7 +3123,7 @@ packages:
       '@sinonjs/commons': 1.8.3
     dev: true
 
-  /@storybook/addon-actions/6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2:
+  /@storybook/addon-actions/6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-oNDiwN8oD2OPKyVcm+dwXk1MJYn+C626FGBWLY8QRdrsMTF3jCKGihY5XFO4AMGNHe6EHy8l+yFWGIcUnpERXw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3134,13 +3134,13 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@storybook/addons': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/api': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/addons': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/api': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/client-logger': 6.5.0-alpha.60
-      '@storybook/components': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/components': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/core-events': 6.5.0-alpha.60
       '@storybook/csf': 0.0.2--canary.7c6c115.0
-      '@storybook/theming': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/theming': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       core-js: 3.21.1
       fast-deep-equal: 3.1.3
       global: 4.4.0
@@ -3157,7 +3157,7 @@ packages:
       uuid-browser: 3.1.0
     dev: true
 
-  /@storybook/addon-backgrounds/6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2:
+  /@storybook/addon-backgrounds/6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-yz07yLFC3Jsh2+msO5QDmI0sdAOfqG/6SsDWZeh7sM3/XoB8wUx7zuPYAW933fsfTvngC3gk80JXq3ijZrgNbA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3168,13 +3168,13 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@storybook/addons': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/api': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/addons': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/api': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/client-logger': 6.5.0-alpha.60
-      '@storybook/components': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/components': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/core-events': 6.5.0-alpha.60
       '@storybook/csf': 0.0.2--canary.7c6c115.0
-      '@storybook/theming': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/theming': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       core-js: 3.21.1
       global: 4.4.0
       memoizerific: 1.11.3
@@ -3185,7 +3185,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/addon-controls/6.5.0-alpha.60_2fb1d923377af186ee0d98bcf52b6020:
+  /@storybook/addon-controls/6.5.0-alpha.60_f6y5sizxplyyn3qntc6pkk3aea:
     resolution: {integrity: sha512-ctNXLC2sq8p5Oqrx1TUOVZM4wnGu1FEvLdy9UFLGk5Ym+XmoZlWIMZ93ovKvGzmWsAs+aS5j8RyJgN3JoSwj1A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3196,15 +3196,15 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@storybook/addons': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/api': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/addons': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/api': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/client-logger': 6.5.0-alpha.60
-      '@storybook/components': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/core-common': 6.5.0-alpha.60_2fb1d923377af186ee0d98bcf52b6020
+      '@storybook/components': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/core-common': 6.5.0-alpha.60_f6y5sizxplyyn3qntc6pkk3aea
       '@storybook/csf': 0.0.2--canary.7c6c115.0
       '@storybook/node-logger': 6.5.0-alpha.60
-      '@storybook/store': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/theming': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/store': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/theming': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       core-js: 3.21.1
       lodash: 4.17.21
       react: 17.0.2
@@ -3219,7 +3219,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/addon-docs/6.5.0-alpha.60_104f5a80348b342b672114276447d073:
+  /@storybook/addon-docs/6.5.0-alpha.60_cbhvvaburm2cwzzbcqtwir6qom:
     resolution: {integrity: sha512-p/wzZ2P8qBHnGb/8j3NZu5g5fE6Qxui9rhrxQVHMMJ0KFy8dqHSNBIGrm0zQCT+bNIZmnsTKxH9hO68RQiuYvQ==}
     peerDependencies:
       '@storybook/mdx2-csf': '*'
@@ -3237,21 +3237,21 @@ packages:
       '@babel/preset-env': 7.16.11_@babel+core@7.17.9
       '@jest/transform': 26.6.2
       '@mdx-js/react': 1.6.22_react@17.0.2
-      '@storybook/addons': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/api': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/components': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/core-common': 6.5.0-alpha.60_2fb1d923377af186ee0d98bcf52b6020
+      '@storybook/addons': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/api': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/components': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/core-common': 6.5.0-alpha.60_f6y5sizxplyyn3qntc6pkk3aea
       '@storybook/core-events': 6.5.0-alpha.60
       '@storybook/csf': 0.0.2--canary.7c6c115.0
-      '@storybook/docs-tools': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/docs-tools': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/mdx1-csf': 0.0.1-canary.1.867dcd5.0_@babel+core@7.17.9
       '@storybook/node-logger': 6.5.0-alpha.60
       '@storybook/postinstall': 6.5.0-alpha.60
-      '@storybook/preview-web': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/source-loader': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/store': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/theming': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      babel-loader: 8.2.4_acba72ea4bf9d339cdfcd8f55cdb7006
+      '@storybook/preview-web': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/source-loader': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/store': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/theming': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      babel-loader: 8.2.4_vs5hf2sl7hjtttp43d2vzw3qay
       core-js: 3.21.1
       fast-deep-equal: 3.1.3
       global: 4.4.0
@@ -3274,7 +3274,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/addon-essentials/6.5.0-alpha.60_104f5a80348b342b672114276447d073:
+  /@storybook/addon-essentials/6.5.0-alpha.60_cbhvvaburm2cwzzbcqtwir6qom:
     resolution: {integrity: sha512-suNmGsiZLDYhazY6zYkcUqMlIO2tTbdRJrEVmCqkuCSDx6yZt8bWipOTi8ZcmSaVbvCtScUUwfCV3fHApUjKdg==}
     peerDependencies:
       '@babel/core': ^7.9.6
@@ -3332,17 +3332,17 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.17.9
-      '@storybook/addon-actions': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/addon-backgrounds': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/addon-controls': 6.5.0-alpha.60_2fb1d923377af186ee0d98bcf52b6020
-      '@storybook/addon-docs': 6.5.0-alpha.60_104f5a80348b342b672114276447d073
-      '@storybook/addon-measure': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/addon-outline': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/addon-toolbars': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/addon-viewport': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/addons': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/api': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/core-common': 6.5.0-alpha.60_2fb1d923377af186ee0d98bcf52b6020
+      '@storybook/addon-actions': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/addon-backgrounds': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/addon-controls': 6.5.0-alpha.60_f6y5sizxplyyn3qntc6pkk3aea
+      '@storybook/addon-docs': 6.5.0-alpha.60_cbhvvaburm2cwzzbcqtwir6qom
+      '@storybook/addon-measure': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/addon-outline': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/addon-toolbars': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/addon-viewport': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/addons': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/api': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/core-common': 6.5.0-alpha.60_f6y5sizxplyyn3qntc6pkk3aea
       '@storybook/node-logger': 6.5.0-alpha.60
       core-js: 3.21.1
       react: 17.0.2
@@ -3360,7 +3360,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/addon-measure/6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2:
+  /@storybook/addon-measure/6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-iZj+gRtLDi38J/sVdMghT14ehaPeywa7CjDP/OsflB3uyzOI7JqWEapL0mudZY2+sbPGID0Tn1BFv5QAoTXb4Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3371,10 +3371,10 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@storybook/addons': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/api': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/addons': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/api': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/client-logger': 6.5.0-alpha.60
-      '@storybook/components': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/components': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/core-events': 6.5.0-alpha.60
       '@storybook/csf': 0.0.2--canary.7c6c115.0
       core-js: 3.21.1
@@ -3383,7 +3383,7 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: true
 
-  /@storybook/addon-outline/6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2:
+  /@storybook/addon-outline/6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-00kUbeMFv0yvHg3vLy/M1XyEx0qNOz31+P3G6XmGss4C1LZTQm3Yoqf1yHVe1T8ynus2jQnzj16n6CfeECbLoQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3394,10 +3394,10 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@storybook/addons': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/api': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/addons': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/api': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/client-logger': 6.5.0-alpha.60
-      '@storybook/components': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/components': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/core-events': 6.5.0-alpha.60
       '@storybook/csf': 0.0.2--canary.7c6c115.0
       core-js: 3.21.1
@@ -3408,7 +3408,7 @@ packages:
       ts-dedent: 2.2.0
     dev: true
 
-  /@storybook/addon-storysource/6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2:
+  /@storybook/addon-storysource/6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-Ofmzfm31S/IjEnsXBMsU/cQNIE5Pmf7/PYbORZqfrSorb2YTDF7oNRioy3U7IeQj4QsL5YVWOzXpVlwgL8DKnA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3419,13 +3419,13 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@storybook/addons': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/api': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/addons': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/api': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/client-logger': 6.5.0-alpha.60
-      '@storybook/components': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/router': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/source-loader': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/theming': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/components': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/router': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/source-loader': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/theming': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       core-js: 3.21.1
       estraverse: 5.3.0
       loader-utils: 2.0.2
@@ -3436,7 +3436,7 @@ packages:
       regenerator-runtime: 0.13.9
     dev: true
 
-  /@storybook/addon-toolbars/6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2:
+  /@storybook/addon-toolbars/6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-iooDbdGm9ZjdZqUkDHwrcdGz7sBAO4htGuDwTIrypZiwNeFAGr3h8nKDXh3jvD67oi+sdBRJ3TQ8xQ/HrujDXA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3447,18 +3447,18 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@storybook/addons': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/api': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/addons': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/api': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/client-logger': 6.5.0-alpha.60
-      '@storybook/components': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/theming': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/components': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/theming': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       core-js: 3.21.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       regenerator-runtime: 0.13.9
     dev: true
 
-  /@storybook/addon-viewport/6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2:
+  /@storybook/addon-viewport/6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-2D1kKCkEq+tE20ET38hP8cRXxh4tqB0ACplxiqnZrnW1RtgeRejbZqvuK0iYMxTsaRWZKNvK3njiKObwUsZiRQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3469,12 +3469,12 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@storybook/addons': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/api': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/addons': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/api': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/client-logger': 6.5.0-alpha.60
-      '@storybook/components': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/components': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/core-events': 6.5.0-alpha.60
-      '@storybook/theming': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/theming': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       core-js: 3.21.1
       global: 4.4.0
       memoizerific: 1.11.3
@@ -3484,19 +3484,19 @@ packages:
       regenerator-runtime: 0.13.9
     dev: true
 
-  /@storybook/addons/6.4.19_react-dom@17.0.2+react@17.0.2:
+  /@storybook/addons/6.4.19_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-QNyRYhpqmHV8oJxxTBdkRlLSbDFhpBvfvMfIrIT1UXb/eemdBZTaCGVvXZ9UixoEEI7f8VwAQ44IvkU5B1509w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@storybook/api': 6.4.19_react-dom@17.0.2+react@17.0.2
+      '@storybook/api': 6.4.19_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/channels': 6.4.19
       '@storybook/client-logger': 6.4.19
       '@storybook/core-events': 6.4.19
       '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/router': 6.4.19_react-dom@17.0.2+react@17.0.2
-      '@storybook/theming': 6.4.19_react-dom@17.0.2+react@17.0.2
+      '@storybook/router': 6.4.19_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/theming': 6.4.19_sfoxds7t5ydpegc3knd667wn6m
       '@types/webpack-env': 1.16.3
       core-js: 3.21.1
       global: 4.4.0
@@ -3505,19 +3505,19 @@ packages:
       regenerator-runtime: 0.13.9
     dev: true
 
-  /@storybook/addons/6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2:
+  /@storybook/addons/6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-BqCGO87gjbPzGOGVEhhRv37Y2vtMpHy0jON6yCFWBB68QdxttXZewkG0icCl3gHe/VruStT5sjiSb6ji46QRow==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@storybook/api': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/api': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/channels': 6.5.0-alpha.60
       '@storybook/client-logger': 6.5.0-alpha.60
       '@storybook/core-events': 6.5.0-alpha.60
       '@storybook/csf': 0.0.2--canary.7c6c115.0
-      '@storybook/router': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/theming': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/router': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/theming': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@types/webpack-env': 1.16.3
       core-js: 3.21.1
       global: 4.4.0
@@ -3526,7 +3526,7 @@ packages:
       regenerator-runtime: 0.13.9
     dev: true
 
-  /@storybook/api/6.4.19_react-dom@17.0.2+react@17.0.2:
+  /@storybook/api/6.4.19_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-aDvea+NpQCBjpNp9YidO1Pr7fzzCp15FSdkG+2ihGQfv5raxrN+IIJnGUXecpe71nvlYiB+29UXBVK7AL0j51Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -3536,9 +3536,9 @@ packages:
       '@storybook/client-logger': 6.4.19
       '@storybook/core-events': 6.4.19
       '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/router': 6.4.19_react-dom@17.0.2+react@17.0.2
+      '@storybook/router': 6.4.19_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/semver': 7.3.2
-      '@storybook/theming': 6.4.19_react-dom@17.0.2+react@17.0.2
+      '@storybook/theming': 6.4.19_sfoxds7t5ydpegc3knd667wn6m
       core-js: 3.21.1
       fast-deep-equal: 3.1.3
       global: 4.4.0
@@ -3553,7 +3553,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/api/6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2:
+  /@storybook/api/6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-lPXjw7gtRwA5gRL+GBWeSGrXZU/mS1Pw3ZX0QL4tDYKaMcNNy86NaV3no5x5jczUOqEokCYWMnhHm53CXeooPw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3563,9 +3563,9 @@ packages:
       '@storybook/client-logger': 6.5.0-alpha.60
       '@storybook/core-events': 6.5.0-alpha.60
       '@storybook/csf': 0.0.2--canary.7c6c115.0
-      '@storybook/router': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/router': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/semver': 7.3.2
-      '@storybook/theming': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/theming': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       core-js: 3.21.1
       fast-deep-equal: 3.1.3
       global: 4.4.0
@@ -3580,7 +3580,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/builder-webpack4/6.5.0-alpha.60_2fb1d923377af186ee0d98bcf52b6020:
+  /@storybook/builder-webpack4/6.5.0-alpha.60_f6y5sizxplyyn3qntc6pkk3aea:
     resolution: {integrity: sha512-m82xpz7siDwShZ6b6BzQ+ki0nOZrEnwL/2+TMWytUlS5OIbaQ/bJeOBVnyafhxolSX5nybalMFcDdf/VmMTKhQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3591,26 +3591,26 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.17.9
-      '@storybook/addons': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/api': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/addons': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/api': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/channel-postmessage': 6.5.0-alpha.60
       '@storybook/channels': 6.5.0-alpha.60
-      '@storybook/client-api': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/client-api': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/client-logger': 6.5.0-alpha.60
-      '@storybook/components': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/core-common': 6.5.0-alpha.60_2fb1d923377af186ee0d98bcf52b6020
+      '@storybook/components': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/core-common': 6.5.0-alpha.60_f6y5sizxplyyn3qntc6pkk3aea
       '@storybook/core-events': 6.5.0-alpha.60
       '@storybook/node-logger': 6.5.0-alpha.60
-      '@storybook/preview-web': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/router': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/preview-web': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/router': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/semver': 7.3.2
-      '@storybook/store': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/theming': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/ui': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/store': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/theming': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/ui': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@types/node': 16.11.26
       '@types/webpack': 4.41.32
       autoprefixer: 9.8.8
-      babel-loader: 8.2.4_598a497cebab8e15ee8f9e5632178e63
+      babel-loader: 8.2.4_lgfes7hlvohbl3uptzldef4omm
       case-sensitive-paths-webpack-plugin: 2.4.0
       core-js: 3.21.1
       css-loader: 3.6.0_webpack@4.46.0
@@ -3624,7 +3624,7 @@ packages:
       pnp-webpack-plugin: 1.6.4_typescript@4.6.3
       postcss: 7.0.39
       postcss-flexbugs-fixes: 4.2.1
-      postcss-loader: 4.3.0_postcss@7.0.39+webpack@4.46.0
+      postcss-loader: 4.3.0_gzaxsinx64nntyd3vmdqwl7coe
       raw-loader: 4.0.2_webpack@4.46.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -3633,7 +3633,7 @@ packages:
       terser-webpack-plugin: 4.2.3_webpack@4.46.0
       ts-dedent: 2.2.0
       typescript: 4.6.3
-      url-loader: 4.1.1_file-loader@6.2.0+webpack@4.46.0
+      url-loader: 4.1.1_lit45vopotvaqup7lrvlnvtxwy
       util-deprecate: 1.0.2
       webpack: 4.46.0
       webpack-dev-middleware: 3.7.3_webpack@4.46.0
@@ -3686,19 +3686,19 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/client-api/6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2:
+  /@storybook/client-api/6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-/LQ+FhIwPzZ2JkemRUDR9I41RuLH7W8y/ZONf5j3sOvaZIetVAdQFmINpl4D49MtGpoeiVQNOaGv8Szpg2NknA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@storybook/addons': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/addons': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/channel-postmessage': 6.5.0-alpha.60
       '@storybook/channels': 6.5.0-alpha.60
       '@storybook/client-logger': 6.5.0-alpha.60
       '@storybook/core-events': 6.5.0-alpha.60
       '@storybook/csf': 0.0.2--canary.7c6c115.0
-      '@storybook/store': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/store': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@types/qs': 6.9.7
       '@types/webpack-env': 1.16.3
       core-js: 3.21.1
@@ -3730,7 +3730,7 @@ packages:
       global: 4.4.0
     dev: true
 
-  /@storybook/components/6.4.19_b49bddbe4b905ced4713cb857cca91fa:
+  /@storybook/components/6.4.19_wsn53pslsboo2rytzocxzsur7i:
     resolution: {integrity: sha512-q/0V37YAJA7CNc+wSiiefeM9+3XVk8ixBNylY36QCGJgIeGQ5/79vPyUe6K4lLmsQwpmZsIq1s1Ad5+VbboeOA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -3739,7 +3739,7 @@ packages:
       '@popperjs/core': 2.11.3
       '@storybook/client-logger': 6.4.19
       '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/theming': 6.4.19_react-dom@17.0.2+react@17.0.2
+      '@storybook/theming': 6.4.19_sfoxds7t5ydpegc3knd667wn6m
       '@types/color-convert': 2.0.0
       '@types/overlayscrollbars': 1.12.1
       '@types/react-syntax-highlighter': 11.0.5
@@ -3754,11 +3754,11 @@ packages:
       polished: 4.2.2
       prop-types: 15.8.1
       react: 17.0.2
-      react-colorful: 5.5.1_react-dom@17.0.2+react@17.0.2
+      react-colorful: 5.5.1_sfoxds7t5ydpegc3knd667wn6m
       react-dom: 17.0.2_react@17.0.2
-      react-popper-tooltip: 3.1.1_react-dom@17.0.2+react@17.0.2
+      react-popper-tooltip: 3.1.1_sfoxds7t5ydpegc3knd667wn6m
       react-syntax-highlighter: 13.5.3_react@17.0.2
-      react-textarea-autosize: 8.3.3_c8e45b4eb687790dba17b4e1c4b4273f
+      react-textarea-autosize: 8.3.3_zdsfwtvwq54q3oqxwtq4jnbhh4
       regenerator-runtime: 0.13.9
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
@@ -3766,7 +3766,7 @@ packages:
       - '@types/react'
     dev: true
 
-  /@storybook/components/6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2:
+  /@storybook/components/6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-iWIkhHEQAUxf+E8wMontZH7/KZHaRhLcVUWD+eVL/0jTok06inxXCyAzqfmwmynnRQPn6A6KNk+o590oMsshmA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3774,14 +3774,14 @@ packages:
     dependencies:
       '@storybook/client-logger': 6.5.0-alpha.60
       '@storybook/csf': 0.0.2--canary.7c6c115.0
-      '@storybook/theming': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/theming': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       core-js: 3.21.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       regenerator-runtime: 0.13.9
     dev: true
 
-  /@storybook/core-client/6.5.0-alpha.60_4077b7c7b8bde62117063dfc3ea342cd:
+  /@storybook/core-client/6.5.0-alpha.60_ib33pr5yxxtccfyghx6d5i2czu:
     resolution: {integrity: sha512-Zezyp8e72vFM5cUjofWvOdaiZy1P1Q6kuYESMoQjhbDIKxluvcTJgYAFWMUUCLbp/ueoFQph7IQWReyqSMj+9A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3792,16 +3792,16 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/addons': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/addons': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/channel-postmessage': 6.5.0-alpha.60
       '@storybook/channel-websocket': 6.5.0-alpha.60
-      '@storybook/client-api': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/client-api': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/client-logger': 6.5.0-alpha.60
       '@storybook/core-events': 6.5.0-alpha.60
       '@storybook/csf': 0.0.2--canary.7c6c115.0
-      '@storybook/preview-web': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/store': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/ui': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/preview-web': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/store': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/ui': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       airbnb-js-shims: 2.2.1
       ansi-to-html: 0.6.15
       core-js: 3.21.1
@@ -3818,7 +3818,7 @@ packages:
       webpack: 5.72.0
     dev: true
 
-  /@storybook/core-client/6.5.0-alpha.60_6e59f5d941c25b90ba6e319d78271eea:
+  /@storybook/core-client/6.5.0-alpha.60_nzm7lwkbyjnzbotoggoxqjy65i:
     resolution: {integrity: sha512-Zezyp8e72vFM5cUjofWvOdaiZy1P1Q6kuYESMoQjhbDIKxluvcTJgYAFWMUUCLbp/ueoFQph7IQWReyqSMj+9A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3829,16 +3829,16 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/addons': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/addons': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/channel-postmessage': 6.5.0-alpha.60
       '@storybook/channel-websocket': 6.5.0-alpha.60
-      '@storybook/client-api': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/client-api': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/client-logger': 6.5.0-alpha.60
       '@storybook/core-events': 6.5.0-alpha.60
       '@storybook/csf': 0.0.2--canary.7c6c115.0
-      '@storybook/preview-web': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/store': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/ui': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/preview-web': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/store': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/ui': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       airbnb-js-shims: 2.2.1
       ansi-to-html: 0.6.15
       core-js: 3.21.1
@@ -3855,7 +3855,7 @@ packages:
       webpack: 4.46.0
     dev: true
 
-  /@storybook/core-common/6.5.0-alpha.60_2fb1d923377af186ee0d98bcf52b6020:
+  /@storybook/core-common/6.5.0-alpha.60_f6y5sizxplyyn3qntc6pkk3aea:
     resolution: {integrity: sha512-ySrZso+mudRuCd/al+Lp/24bhXDBk5C6kzItYzJqBBpc8l5sORoVjZA/lm0XtWT0Oaav13qUzbKZhbwH7fZfXQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3891,7 +3891,7 @@ packages:
       '@storybook/semver': 7.3.2
       '@types/node': 16.11.26
       '@types/pretty-hrtime': 1.0.1
-      babel-loader: 8.2.4_598a497cebab8e15ee8f9e5632178e63
+      babel-loader: 8.2.4_lgfes7hlvohbl3uptzldef4omm
       babel-plugin-macros: 3.1.0
       babel-plugin-polyfill-corejs3: 0.1.7_@babel+core@7.17.9
       chalk: 4.1.2
@@ -3899,7 +3899,7 @@ packages:
       express: 4.17.3
       file-system-cache: 1.0.5
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.0_3e7f220833949118e6f92b767ea7dfdd
+      fork-ts-checker-webpack-plugin: 6.5.0_hz7secbtssirrzxzfn3h5j673u
       fs-extra: 9.1.0
       glob: 7.2.0
       handlebars: 4.7.7
@@ -3938,7 +3938,7 @@ packages:
       core-js: 3.21.1
     dev: true
 
-  /@storybook/core-server/6.5.0-alpha.60_2fb1d923377af186ee0d98bcf52b6020:
+  /@storybook/core-server/6.5.0-alpha.60_f6y5sizxplyyn3qntc6pkk3aea:
     resolution: {integrity: sha512-kp/cuvBRaWUMS4SUJD2XYTe9o6g4n204/YH85X0dSRZdMs2/D/wAoS1c2Gnn6C7ndcN8WXX6F697QYAnnkeXTQ==}
     peerDependencies:
       '@storybook/builder-webpack5': '*'
@@ -3955,16 +3955,16 @@ packages:
         optional: true
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@storybook/builder-webpack4': 6.5.0-alpha.60_2fb1d923377af186ee0d98bcf52b6020
-      '@storybook/core-client': 6.5.0-alpha.60_6e59f5d941c25b90ba6e319d78271eea
-      '@storybook/core-common': 6.5.0-alpha.60_2fb1d923377af186ee0d98bcf52b6020
+      '@storybook/builder-webpack4': 6.5.0-alpha.60_f6y5sizxplyyn3qntc6pkk3aea
+      '@storybook/core-client': 6.5.0-alpha.60_nzm7lwkbyjnzbotoggoxqjy65i
+      '@storybook/core-common': 6.5.0-alpha.60_f6y5sizxplyyn3qntc6pkk3aea
       '@storybook/core-events': 6.5.0-alpha.60
       '@storybook/csf': 0.0.2--canary.7c6c115.0
       '@storybook/csf-tools': 6.5.0-alpha.60
-      '@storybook/manager-webpack4': 6.5.0-alpha.60_2fb1d923377af186ee0d98bcf52b6020
+      '@storybook/manager-webpack4': 6.5.0-alpha.60_f6y5sizxplyyn3qntc6pkk3aea
       '@storybook/node-logger': 6.5.0-alpha.60
       '@storybook/semver': 7.3.2
-      '@storybook/store': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/store': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@types/node': 16.11.26
       '@types/node-fetch': 2.6.1
       '@types/pretty-hrtime': 1.0.1
@@ -4013,7 +4013,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/core/6.5.0-alpha.60_4cdad558125416cc5d72dc9617822e96:
+  /@storybook/core/6.5.0-alpha.60_jtnnkwaskqlmyxls3slbparosy:
     resolution: {integrity: sha512-xWYgz3jm1vi3p6mo2ka5Vqi4VRq7TjuroLsn3XU7xnZx+/1B8tUUzeN3Q/PWKACkfTQ2/zGBlY+zQfbPEaSOtA==}
     peerDependencies:
       '@storybook/builder-webpack5': '*'
@@ -4030,8 +4030,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/core-client': 6.5.0-alpha.60_4077b7c7b8bde62117063dfc3ea342cd
-      '@storybook/core-server': 6.5.0-alpha.60_2fb1d923377af186ee0d98bcf52b6020
+      '@storybook/core-client': 6.5.0-alpha.60_ib33pr5yxxtccfyghx6d5i2czu
+      '@storybook/core-server': 6.5.0-alpha.60_f6y5sizxplyyn3qntc6pkk3aea
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       typescript: 4.6.3
@@ -4092,12 +4092,12 @@ packages:
       lodash: 4.17.21
     dev: true
 
-  /@storybook/docs-tools/6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2:
+  /@storybook/docs-tools/6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-+kn/6ZeDhM0gkVkGvB4k8bJWKes6xCPwkmNUlqfd33/ndb3M0T0RAXWV73VxEpPGNcoJM2neupw2/yUWc5Uu8Q==}
     dependencies:
       '@babel/core': 7.17.9
       '@storybook/csf': 0.0.2--canary.7c6c115.0
-      '@storybook/store': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/store': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       core-js: 3.21.1
       doctrine: 3.0.0
       lodash: 4.17.21
@@ -4108,7 +4108,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/manager-webpack4/6.5.0-alpha.60_2fb1d923377af186ee0d98bcf52b6020:
+  /@storybook/manager-webpack4/6.5.0-alpha.60_f6y5sizxplyyn3qntc6pkk3aea:
     resolution: {integrity: sha512-WWZHHZAtHtcD6gLlN/AXrbmqyslUa59AUB5/vku2r0JVSW6soQE/k5nkL/JOj18FJpAFcQr1oBgcHrEg8LdsuQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -4121,15 +4121,15 @@ packages:
       '@babel/core': 7.17.9
       '@babel/plugin-transform-template-literals': 7.16.7_@babel+core@7.17.9
       '@babel/preset-react': 7.16.7_@babel+core@7.17.9
-      '@storybook/addons': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/core-client': 6.5.0-alpha.60_6e59f5d941c25b90ba6e319d78271eea
-      '@storybook/core-common': 6.5.0-alpha.60_2fb1d923377af186ee0d98bcf52b6020
+      '@storybook/addons': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/core-client': 6.5.0-alpha.60_nzm7lwkbyjnzbotoggoxqjy65i
+      '@storybook/core-common': 6.5.0-alpha.60_f6y5sizxplyyn3qntc6pkk3aea
       '@storybook/node-logger': 6.5.0-alpha.60
-      '@storybook/theming': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/ui': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/theming': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/ui': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@types/node': 16.11.26
       '@types/webpack': 4.41.32
-      babel-loader: 8.2.4_598a497cebab8e15ee8f9e5632178e63
+      babel-loader: 8.2.4_lgfes7hlvohbl3uptzldef4omm
       case-sensitive-paths-webpack-plugin: 2.4.0
       chalk: 4.1.2
       core-js: 3.21.1
@@ -4151,7 +4151,7 @@ packages:
       terser-webpack-plugin: 4.2.3_webpack@4.46.0
       ts-dedent: 2.2.0
       typescript: 4.6.3
-      url-loader: 4.1.1_file-loader@6.2.0+webpack@4.46.0
+      url-loader: 4.1.1_lit45vopotvaqup7lrvlnvtxwy
       util-deprecate: 1.0.2
       webpack: 4.46.0
       webpack-dev-middleware: 3.7.3_webpack@4.46.0
@@ -4200,18 +4200,18 @@ packages:
       core-js: 3.21.1
     dev: true
 
-  /@storybook/preview-web/6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2:
+  /@storybook/preview-web/6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-oWDM72yveosIf9vPjhHc3ZqE+UdO6bK1JcJCdqLJpSp1PSqYTEiWvTreD1paGpXpFXblaBF9p2JrvztQp3iX1Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@storybook/addons': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/addons': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/channel-postmessage': 6.5.0-alpha.60
       '@storybook/client-logger': 6.5.0-alpha.60
       '@storybook/core-events': 6.5.0-alpha.60
       '@storybook/csf': 0.0.2--canary.7c6c115.0
-      '@storybook/store': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/store': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       ansi-to-html: 0.6.15
       core-js: 3.21.1
       global: 4.4.0
@@ -4226,7 +4226,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/react-docgen-typescript-plugin/1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_typescript@4.6.3+webpack@5.72.0:
+  /@storybook/react-docgen-typescript-plugin/1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_4dvvomwfbhpgf7xcm7gogbdvgu:
     resolution: {integrity: sha512-eVg3BxlOm2P+chijHBTByr90IZVUtgRW56qEOLX7xlww2NBuKrcavBlcmn+HH7GIUktquWkMPtvy6e0W0NgA5w==}
     peerDependencies:
       typescript: '>= 3.x'
@@ -4245,7 +4245,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/react/6.5.0-alpha.60_53061357d4abbea43324b67fa10c9322:
+  /@storybook/react/6.5.0-alpha.60_kmdbgv6uvo7kimzewz72cdetei:
     resolution: {integrity: sha512-UMvPwIaYs94Da/tFJyhTd72Apg+lMDevSTCUwCi5GTwkgN51vRLUrFkVZRnQSC3l9gCeVcfu+LIAaFZ+22ucyg==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -4277,17 +4277,17 @@ packages:
       '@babel/core': 7.17.9
       '@babel/preset-flow': 7.16.7_@babel+core@7.17.9
       '@babel/preset-react': 7.16.7_@babel+core@7.17.9
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.4_a6ddf6349bbfbae23464eb7cd0d9bae7
-      '@storybook/addons': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.4_u3o7mne3x65oende5n6nbwn244
+      '@storybook/addons': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/client-logger': 6.5.0-alpha.60
-      '@storybook/core': 6.5.0-alpha.60_4cdad558125416cc5d72dc9617822e96
-      '@storybook/core-common': 6.5.0-alpha.60_2fb1d923377af186ee0d98bcf52b6020
+      '@storybook/core': 6.5.0-alpha.60_jtnnkwaskqlmyxls3slbparosy
+      '@storybook/core-common': 6.5.0-alpha.60_f6y5sizxplyyn3qntc6pkk3aea
       '@storybook/csf': 0.0.2--canary.7c6c115.0
-      '@storybook/docs-tools': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/docs-tools': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/node-logger': 6.5.0-alpha.60
-      '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_typescript@4.6.3+webpack@5.72.0
+      '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_4dvvomwfbhpgf7xcm7gogbdvgu
       '@storybook/semver': 7.3.2
-      '@storybook/store': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/store': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@types/estree': 0.0.51
       '@types/node': 16.11.26
       '@types/webpack-env': 1.16.3
@@ -4305,7 +4305,7 @@ packages:
       prop-types: 15.8.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-element-to-jsx-string: 14.3.4_react-dom@17.0.2+react@17.0.2
+      react-element-to-jsx-string: 14.3.4_sfoxds7t5ydpegc3knd667wn6m
       react-refresh: 0.11.0
       read-pkg-up: 7.0.1
       regenerator-runtime: 0.13.9
@@ -4335,7 +4335,7 @@ packages:
       - webpack-plugin-serve
     dev: true
 
-  /@storybook/router/6.4.19_react-dom@17.0.2+react@17.0.2:
+  /@storybook/router/6.4.19_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-KWWwIzuyeEIWVezkCihwY2A76Il9tUNg0I410g9qT7NrEsKyqXGRYOijWub7c1GGyNjLqz0jtrrehtixMcJkuA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -4352,11 +4352,11 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-router: 6.2.2_react@17.0.2
-      react-router-dom: 6.2.2_react-dom@17.0.2+react@17.0.2
+      react-router-dom: 6.2.2_sfoxds7t5ydpegc3knd667wn6m
       ts-dedent: 2.2.0
     dev: true
 
-  /@storybook/router/6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2:
+  /@storybook/router/6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-n+9HEDG1AkIazrisKiEzX8B+sGvXFfmo7M5ZBBoahd6Ep8Hysv4sTLXDjTN9HkPopV+m4kkDvf48NgrBEeUibA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -4378,13 +4378,13 @@ packages:
       find-up: 4.1.0
     dev: true
 
-  /@storybook/source-loader/6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2:
+  /@storybook/source-loader/6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-BR0P9hMDz/yMe18mtAVmLyCtVjfx6+iI7HObCsl3itq6vDVcwSu0oOGvlTR4zGyylqbOys7ksa2Xz0dQUk+5Gg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@storybook/addons': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/addons': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/client-logger': 6.5.0-alpha.60
       '@storybook/csf': 0.0.2--canary.7c6c115.0
       core-js: 3.21.1
@@ -4398,13 +4398,13 @@ packages:
       regenerator-runtime: 0.13.9
     dev: true
 
-  /@storybook/store/6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2:
+  /@storybook/store/6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-d9mSw9C/FVEBJSge+yjNWHxo5R6xtQ0BuRchGdbJZ+xbXwNonyOj0sPx6upHpaSpVWxbm75aD8rQKRgpcOw6gA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@storybook/addons': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/addons': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/client-logger': 6.5.0-alpha.60
       '@storybook/core-events': 6.5.0-alpha.60
       '@storybook/csf': 0.0.2--canary.7c6c115.0
@@ -4423,7 +4423,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/theming/6.4.19_react-dom@17.0.2+react@17.0.2:
+  /@storybook/theming/6.4.19_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-V4pWmTvAxmbHR6B3jA4hPkaxZPyExHvCToy7b76DpUTpuHihijNDMAn85KhOQYIeL9q14zP/aiz899tOHsOidg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -4431,11 +4431,11 @@ packages:
     dependencies:
       '@emotion/core': 10.3.1_react@17.0.2
       '@emotion/is-prop-valid': 0.8.8
-      '@emotion/styled': 10.3.0_316248eb6686a2fd4fbadcfd00de37f3
+      '@emotion/styled': 10.3.0_gfrer23gq2rp2t523t6qbxrx6m
       '@storybook/client-logger': 6.4.19
       core-js: 3.21.1
       deep-object-diff: 1.1.7
-      emotion-theming: 10.3.0_316248eb6686a2fd4fbadcfd00de37f3
+      emotion-theming: 10.3.0_gfrer23gq2rp2t523t6qbxrx6m
       global: 4.4.0
       memoizerific: 1.11.3
       polished: 4.2.2
@@ -4445,7 +4445,7 @@ packages:
       ts-dedent: 2.2.0
     dev: true
 
-  /@storybook/theming/6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2:
+  /@storybook/theming/6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-n4TjLkq2LqqDVWG5xMoBAk4nfUfUiOeflOtIpcDgNO54Op1alomuqIo0+OoVh586OvMI4X3JjdACgme26jHEyg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -4458,21 +4458,21 @@ packages:
       regenerator-runtime: 0.13.9
     dev: true
 
-  /@storybook/ui/6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2:
+  /@storybook/ui/6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-KlfKiziXKF5luWhlKAdf6vkPcaLwaiiaDx9EzmvZnOdATvzsTK72xpfVa477Mf1WKURmooDBqDbnJARc/7pBsA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@storybook/addons': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
-      '@storybook/api': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/addons': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/api': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/channels': 6.5.0-alpha.60
       '@storybook/client-logger': 6.5.0-alpha.60
-      '@storybook/components': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/components': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/core-events': 6.5.0-alpha.60
-      '@storybook/router': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/router': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/semver': 7.3.2
-      '@storybook/theming': 6.5.0-alpha.60_react-dom@17.0.2+react@17.0.2
+      '@storybook/theming': 6.5.0-alpha.60_sfoxds7t5ydpegc3knd667wn6m
       core-js: 3.21.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -4537,7 +4537,7 @@ packages:
       redent: 3.0.0
     dev: true
 
-  /@testing-library/react/12.1.4_react-dom@17.0.2+react@17.0.2:
+  /@testing-library/react/12.1.4_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-jiPKOm7vyUw311Hn/HlNQ9P8/lHNtArAx0PisXyFixDDvfl8DbD6EUdbshK5eqauvBSvzZd19itqQ9j3nferJA==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -4900,7 +4900,8 @@ packages:
       '@types/hoist-non-react-statics': 3.3.1
       '@types/react': 17.0.44
       hoist-non-react-statics: 3.3.2
-      redux: 4.1.2
+      redux: 4.2.0
+    dev: true
 
   /@types/react-syntax-highlighter/11.0.5:
     resolution: {integrity: sha512-VIOi9i2Oj5XsmWWoB72p3KlZoEbdRAcechJa8Ztebw7bDl2YmR+odxIqhtJGp1q2EozHs02US+gzxJ9nuf56qg==}
@@ -4994,6 +4995,10 @@ packages:
     resolution: {integrity: sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==}
     dev: true
 
+  /@types/use-sync-external-store/0.0.3:
+    resolution: {integrity: sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==}
+    dev: false
+
   /@types/webpack-env/1.16.3:
     resolution: {integrity: sha512-9gtOPPkfyNoEqCQgx4qJKkuNm/x0R2hKR7fdl7zvTJyHnIisuE/LfvXOsYWL0o3qq6uiBnKZNNNzi3l0y/X+xw==}
     dev: true
@@ -5041,7 +5046,7 @@ packages:
     dev: true
     optional: true
 
-  /@typescript-eslint/eslint-plugin/5.18.0_0dd9be2ba5ed9805045f3fec8be848f5:
+  /@typescript-eslint/eslint-plugin/5.18.0_bxm34k5f5wmakbc7h7wix2ci6u:
     resolution: {integrity: sha512-tzrmdGMJI/uii9/V6lurMo4/o+dMTKDH82LkNjhJ3adCW22YQydoRs5MwTiqxGF9CSYxPxQ7EYb4jLNlIs+E+A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5052,10 +5057,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.18.0_eslint@8.13.0+typescript@4.6.3
+      '@typescript-eslint/parser': 5.18.0_jzhokl4shvj5szf5bgr66kln2a
       '@typescript-eslint/scope-manager': 5.18.0
-      '@typescript-eslint/type-utils': 5.18.0_eslint@8.13.0+typescript@4.6.3
-      '@typescript-eslint/utils': 5.18.0_eslint@8.13.0+typescript@4.6.3
+      '@typescript-eslint/type-utils': 5.18.0_jzhokl4shvj5szf5bgr66kln2a
+      '@typescript-eslint/utils': 5.18.0_jzhokl4shvj5szf5bgr66kln2a
       debug: 4.3.4
       eslint: 8.13.0
       functional-red-black-tree: 1.0.1
@@ -5068,20 +5073,20 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/experimental-utils/5.14.0_eslint@8.13.0+typescript@4.6.3:
+  /@typescript-eslint/experimental-utils/5.14.0_jzhokl4shvj5szf5bgr66kln2a:
     resolution: {integrity: sha512-ke48La1A/TWAn949cdgQiP3oK0NT7ArhDAOVOmNLVjT/uAXlFyrJY8dM4qqxHrATzIp8glg+G2OZjy2lRKBIUA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.14.0_eslint@8.13.0+typescript@4.6.3
+      '@typescript-eslint/utils': 5.14.0_jzhokl4shvj5szf5bgr66kln2a
       eslint: 8.13.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@typescript-eslint/parser/5.18.0_eslint@8.13.0+typescript@4.6.3:
+  /@typescript-eslint/parser/5.18.0_jzhokl4shvj5szf5bgr66kln2a:
     resolution: {integrity: sha512-+08nYfurBzSSPndngnHvFw/fniWYJ5ymOrn/63oMIbgomVQOvIDhBoJmYZ9lwQOCnQV9xHGvf88ze3jFGUYooQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5117,7 +5122,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.18.0
     dev: true
 
-  /@typescript-eslint/type-utils/5.18.0_eslint@8.13.0+typescript@4.6.3:
+  /@typescript-eslint/type-utils/5.18.0_jzhokl4shvj5szf5bgr66kln2a:
     resolution: {integrity: sha512-vcn9/6J5D6jtHxpEJrgK8FhaM8r6J1/ZiNu70ZUJN554Y3D9t3iovi6u7JF8l/e7FcBIxeuTEidZDR70UuCIfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5127,7 +5132,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 5.18.0_eslint@8.13.0+typescript@4.6.3
+      '@typescript-eslint/utils': 5.18.0_jzhokl4shvj5szf5bgr66kln2a
       debug: 4.3.4
       eslint: 8.13.0
       tsutils: 3.21.0_typescript@4.6.3
@@ -5188,7 +5193,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.14.0_eslint@8.13.0+typescript@4.6.3:
+  /@typescript-eslint/utils/5.14.0_jzhokl4shvj5szf5bgr66kln2a:
     resolution: {integrity: sha512-EHwlII5mvUA0UsKYnVzySb/5EE/t03duUTweVy8Zqt3UQXBrpEVY144OTceFKaOe4xQXZJrkptCf7PjEBeGK4w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5206,7 +5211,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils/5.18.0_eslint@8.13.0+typescript@4.6.3:
+  /@typescript-eslint/utils/5.18.0_jzhokl4shvj5szf5bgr66kln2a:
     resolution: {integrity: sha512-+hFGWUMMri7OFY26TsOlGa+zgjEy1ssEipxpLjtl4wSll8zy85x0GrUSju/FHdKfVorZPYJLkF3I4XPtnCTewA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5473,7 +5478,7 @@ packages:
       '@xtuc/long': 4.2.2
     dev: true
 
-  /@wojtekmaj/enzyme-adapter-react-17/0.6.7_fae758709a8810ba97b4c03852dde4d0:
+  /@wojtekmaj/enzyme-adapter-react-17/0.6.7_7ltvq4e2railvf5uya4ffxpe2a:
     resolution: {integrity: sha512-B+byiwi/T1bx5hcj9wc0fUL5Hlb5giSXJzcnEfJVl2j6dGV2NJfcxDBYX0WWwIxlzNiFz8kAvlkFWI2y/nscZQ==}
     peerDependencies:
       enzyme: ^3.0.0
@@ -5503,7 +5508,7 @@ packages:
       react: 17.0.2
     dev: true
 
-  /@xstate/react/1.6.3_7ce6a90b9093193255e12b5a0fae8c89:
+  /@xstate/react/1.6.3_pttksc4qsmmtevpbfnna7lumre:
     resolution: {integrity: sha512-NCUReRHPGvvCvj2yLZUTfR0qVp6+apc8G83oXSjN4rl89ZjyujiKrTff55bze/HrsvCsP/sUJASf2n0nzMF1KQ==}
     peerDependencies:
       '@xstate/fsm': ^1.0.0
@@ -5516,7 +5521,7 @@ packages:
         optional: true
     dependencies:
       react: 17.0.2
-      use-isomorphic-layout-effect: 1.1.1_c8e45b4eb687790dba17b4e1c4b4273f
+      use-isomorphic-layout-effect: 1.1.1_zdsfwtvwq54q3oqxwtq4jnbhh4
       use-subscription: 1.5.1_react@17.0.2
       xstate: 4.30.6
     transitivePeerDependencies:
@@ -6130,7 +6135,7 @@ packages:
       - supports-color
     dev: true
 
-  /babel-loader/8.2.4_598a497cebab8e15ee8f9e5632178e63:
+  /babel-loader/8.2.4_lgfes7hlvohbl3uptzldef4omm:
     resolution: {integrity: sha512-8dytA3gcvPPPv4Grjhnt8b5IIiTcq/zeXOPk4iTYI0SVXcsmuGg7JtBRDp8S9X+gJfhQ8ektjXZlDu1Bb33U8A==}
     engines: {node: '>= 8.9'}
     peerDependencies:
@@ -6145,7 +6150,7 @@ packages:
       webpack: 4.46.0
     dev: true
 
-  /babel-loader/8.2.4_acba72ea4bf9d339cdfcd8f55cdb7006:
+  /babel-loader/8.2.4_vs5hf2sl7hjtttp43d2vzw3qay:
     resolution: {integrity: sha512-8dytA3gcvPPPv4Grjhnt8b5IIiTcq/zeXOPk4iTYI0SVXcsmuGg7JtBRDp8S9X+gJfhQ8ektjXZlDu1Bb33U8A==}
     engines: {node: '>= 8.9'}
     peerDependencies:
@@ -6328,7 +6333,7 @@ packages:
       babel-plugin-syntax-jsx: 6.18.0
       lodash: 4.17.21
       picomatch: 2.3.1
-      styled-components: 5.3.5_react-dom@17.0.2+react@17.0.2
+      styled-components: 5.3.5_sfoxds7t5ydpegc3knd667wn6m
     dev: true
 
   /babel-plugin-syntax-jsx/6.18.0:
@@ -7607,7 +7612,7 @@ packages:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
     dev: true
 
-  /cosmiconfig-typescript-loader/1.0.6_ddaac8e123aeb260f586984cee874848:
+  /cosmiconfig-typescript-loader/1.0.6_3wvmryjdv2zgb5mgtbgo5b2ija:
     resolution: {integrity: sha512-2nEotziYJWtNtoTjKbchj9QrdTT6DBxCvqjNKoDKARw+e2yZmTQCa07uRrykLIZuvSgp69YXLH89UHc0WhdMfQ==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
@@ -7616,7 +7621,7 @@ packages:
     dependencies:
       '@types/node': 16.11.26
       cosmiconfig: 7.0.1
-      ts-node: 10.7.0_ddaac8e123aeb260f586984cee874848
+      ts-node: 10.7.0_3wvmryjdv2zgb5mgtbgo5b2ija
       typescript: 4.6.3
     transitivePeerDependencies:
       - '@swc/core'
@@ -8460,7 +8465,7 @@ packages:
     engines: {node: '>= 4'}
     dev: true
 
-  /emotion-theming/10.3.0_316248eb6686a2fd4fbadcfd00de37f3:
+  /emotion-theming/10.3.0_gfrer23gq2rp2t523t6qbxrx6m:
     resolution: {integrity: sha512-mXiD2Oj7N9b6+h/dC6oLf9hwxbtKHQjoIqtodEyL8CpkN4F3V4IK/BT4D0C7zSs4BBFOu4UlPJbvvBLa88SGEA==}
     peerDependencies:
       '@emotion/core': ^10.0.27
@@ -8528,7 +8533,7 @@ packages:
     resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
     dev: true
 
-  /enzyme-adapter-react-16/1.15.6_fae758709a8810ba97b4c03852dde4d0:
+  /enzyme-adapter-react-16/1.15.6_7ltvq4e2railvf5uya4ffxpe2a:
     resolution: {integrity: sha512-yFlVJCXh8T+mcQo8M6my9sPgeGzj85HSHi6Apgf1Cvq/7EL/J9+1JoJmJsRxZgyTvPMAqOEpRSu/Ii/ZpyOk0g==}
     peerDependencies:
       enzyme: ^3.0.0
@@ -8724,7 +8729,7 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /eslint-config-airbnb-base/15.0.0_25dbcfb8cfecb7418ebda712664abe37:
+  /eslint-config-airbnb-base/15.0.0_exn47ogp5s3uddv5u4jgmsv6g4:
     resolution: {integrity: sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -8739,7 +8744,7 @@ packages:
       semver: 6.3.0
     dev: true
 
-  /eslint-config-airbnb/19.0.4_98153b3cb1eb5f851029189077e45ffc:
+  /eslint-config-airbnb/19.0.4_taktwpfr5npykebjdcihpzc77q:
     resolution: {integrity: sha512-T75QYQVQX57jiNgpF9r1KegMICE94VYwoFQyMGhrvc+lB8YF2E/M/PYDaQe1AJcWaEgqLE+ErXV1Og/+6Vyzew==}
     engines: {node: ^10.12.0 || ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -8750,7 +8755,7 @@ packages:
       eslint-plugin-react-hooks: ^4.3.0
     dependencies:
       eslint: 8.13.0
-      eslint-config-airbnb-base: 15.0.0_25dbcfb8cfecb7418ebda712664abe37
+      eslint-config-airbnb-base: 15.0.0_exn47ogp5s3uddv5u4jgmsv6g4
       eslint-plugin-import: 2.26.0_eslint@8.13.0
       eslint-plugin-jsx-a11y: 6.5.1_eslint@8.13.0
       eslint-plugin-react: 7.29.4_eslint@8.13.0
@@ -8775,7 +8780,7 @@ packages:
       resolve: 1.22.0
     dev: true
 
-  /eslint-import-resolver-typescript/2.7.1_25dbcfb8cfecb7418ebda712664abe37:
+  /eslint-import-resolver-typescript/2.7.1_exn47ogp5s3uddv5u4jgmsv6g4:
     resolution: {integrity: sha512-00UbgGwV8bSgUv34igBDbTOtKhqoRMy9bFjNehT40bXg6585PNIct8HhXZ0SybqB9rWtXj9crcku8ndDn/gIqQ==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -8851,7 +8856,7 @@ packages:
       tsconfig-paths: 3.14.1
     dev: true
 
-  /eslint-plugin-jest/26.1.4_3d39dff4be9be9ebd9147828001ec409:
+  /eslint-plugin-jest/26.1.4_hu4575f6tpu6xwiupauaahwebe:
     resolution: {integrity: sha512-wgqxujmqc2qpvZqMFWCh6Cniqc8lWpapvXt9j/19DmBDqeDaYhJrSRezYR1SKyemvjx+9e9kny/dgRahraHImA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -8864,8 +8869,8 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.18.0_0dd9be2ba5ed9805045f3fec8be848f5
-      '@typescript-eslint/utils': 5.18.0_eslint@8.13.0+typescript@4.6.3
+      '@typescript-eslint/eslint-plugin': 5.18.0_bxm34k5f5wmakbc7h7wix2ci6u
+      '@typescript-eslint/utils': 5.18.0_jzhokl4shvj5szf5bgr66kln2a
       eslint: 8.13.0
       jest: 27.5.1
     transitivePeerDependencies:
@@ -8909,7 +8914,7 @@ packages:
       semver: 6.3.0
     dev: true
 
-  /eslint-plugin-prettier/4.0.0_1815ac95b7fb26c13c7d48a8eef62d0f:
+  /eslint-plugin-prettier/4.0.0_dak2zfnx7mtmcpd5jcuo55rnb4:
     resolution: {integrity: sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==}
     engines: {node: '>=6.0.0'}
     peerDependencies:
@@ -8958,14 +8963,14 @@ packages:
       string.prototype.matchall: 4.0.6
     dev: true
 
-  /eslint-plugin-storybook/0.5.8_eslint@8.13.0+typescript@4.6.3:
+  /eslint-plugin-storybook/0.5.8_jzhokl4shvj5szf5bgr66kln2a:
     resolution: {integrity: sha512-k67mXT9dOl0z8RFWL9SAQ38NaNst6BjCUDQudaDGjMJHrXncOfCSOz9ROGIVu//zVepZw8D3abdGn9OVvyJ3QA==}
     engines: {node: 12.x || 14.x || >= 16}
     peerDependencies:
       eslint: '>=6'
     dependencies:
       '@storybook/csf': 0.0.1
-      '@typescript-eslint/experimental-utils': 5.14.0_eslint@8.13.0+typescript@4.6.3
+      '@typescript-eslint/experimental-utils': 5.14.0_jzhokl4shvj5szf5bgr66kln2a
       eslint: 8.13.0
       requireindex: 1.2.0
     transitivePeerDependencies:
@@ -9669,7 +9674,7 @@ packages:
       worker-rpc: 0.1.1
     dev: true
 
-  /fork-ts-checker-webpack-plugin/6.5.0_3e7f220833949118e6f92b767ea7dfdd:
+  /fork-ts-checker-webpack-plugin/6.5.0_hz7secbtssirrzxzfn3h5j673u:
     resolution: {integrity: sha512-cS178Y+xxtIjEUorcHddKS7yCMlrDPV31mt47blKKRfMd70Kxu5xruAFE2o9sDY6wVC5deuob/u/alD04YYHnw==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -11990,6 +11995,7 @@ packages:
 
   /js-tokens/4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    dev: true
 
   /js-yaml/3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
@@ -12563,6 +12569,7 @@ packages:
     hasBin: true
     dependencies:
       js-tokens: 4.0.0
+    dev: true
 
   /loud-rejection/1.6.0:
     resolution: {integrity: sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=}
@@ -13346,6 +13353,7 @@ packages:
   /object-assign/4.1.1:
     resolution: {integrity: sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /object-copy/0.1.0:
     resolution: {integrity: sha1-fn2Fi3gb18mRpBupde04EnVOmYw=}
@@ -14013,7 +14021,7 @@ packages:
       postcss: 7.0.39
     dev: true
 
-  /postcss-loader/4.3.0_postcss@7.0.39+webpack@4.46.0:
+  /postcss-loader/4.3.0_gzaxsinx64nntyd3vmdqwl7coe:
     resolution: {integrity: sha512-M/dSoIiNDOo8Rk0mUqoj4kpGq91gcxCfb9PoyZVdZ76/AuhxylHDYZblNE8o+EQ9AMSASeMFEKxZf5aU6wlx1Q==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -14251,6 +14259,7 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+    dev: true
 
   /property-information/5.6.0:
     resolution: {integrity: sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==}
@@ -14482,7 +14491,7 @@ packages:
       strip-json-comments: 2.0.1
     dev: true
 
-  /react-colorful/5.5.1_react-dom@17.0.2+react@17.0.2:
+  /react-colorful/5.5.1_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-M1TJH2X3RXEt12sWkpa6hLc/bbYS0H6F4rIqjQZ+RxNBstpY67d9TrFXtqdZwhpmBXcCwEi7stKqFue3ZRkiOg==}
     peerDependencies:
       react: '>=16.8.0'
@@ -14542,7 +14551,7 @@ packages:
       scheduler: 0.20.2
     dev: true
 
-  /react-element-to-jsx-string/14.3.4_react-dom@17.0.2+react@17.0.2:
+  /react-element-to-jsx-string/14.3.4_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-t4ZwvV6vwNxzujDQ+37bspnLwA4JlgUPWhLjBJWsNIDceAf6ZKUTCjdm08cN6WeZ5pTMKiCJkmAYnpmR4Bm+dg==}
     peerDependencies:
       react: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1
@@ -14575,12 +14584,17 @@ packages:
 
   /react-is/17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+    dev: true
+
+  /react-is/18.0.0:
+    resolution: {integrity: sha512-yUcBYdBBbo3QiPsgYDcfQcIkGZHfxOaoE6HLSnr1sPzMhdyxusbfKOSUbSd/ocGi32dxcj366PsTj+5oggeKKw==}
+    dev: false
 
   /react-lifecycles-compat/3.0.4:
     resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
     dev: true
 
-  /react-popper-tooltip/3.1.1_react-dom@17.0.2+react@17.0.2:
+  /react-popper-tooltip/3.1.1_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-EnERAnnKRptQBJyaee5GJScWNUKQPDD2ywvzZyUjst/wj5U64C8/CnSYLNEmP2hG0IJ3ZhtDxE8oDN+KOyavXQ==}
     peerDependencies:
       react: ^16.6.0 || ^17.0.0
@@ -14590,10 +14604,10 @@ packages:
       '@popperjs/core': 2.11.3
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-popper: 2.2.5_06a9b8e78719e808c2e8185e88e50f2c
+      react-popper: 2.2.5_a2u3rz4hdhuarqxidbpirzipfq
     dev: true
 
-  /react-popper/2.2.5_06a9b8e78719e808c2e8185e88e50f2c:
+  /react-popper/2.2.5_a2u3rz4hdhuarqxidbpirzipfq:
     resolution: {integrity: sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==}
     peerDependencies:
       '@popperjs/core': ^2.0.0
@@ -14605,26 +14619,38 @@ packages:
       warning: 4.0.3
     dev: true
 
-  /react-redux/7.2.8_react-dom@17.0.2+react@17.0.2:
-    resolution: {integrity: sha512-6+uDjhs3PSIclqoCk0kd6iX74gzrGc3W5zcAjbrFgEdIjRSQObdIwfx80unTkVUYvbQ95Y8Av3OvFHq1w5EOUw==}
+  /react-redux/8.0.1_ihq5kkl6mjij4qge27qzzrokfq:
+    resolution: {integrity: sha512-LMZMsPY4DYdZfLJgd7i79n5Kps5N9XVLCJJeWAaPYTV+Eah2zTuBjTxKtNEbjiyitbq80/eIkm55CYSLqAub3w==}
     peerDependencies:
-      react: ^16.8.3 || ^17 || ^18
-      react-dom: '*'
-      react-native: '*'
+      '@types/react': ^16.8 || ^17.0 || ^18.0
+      '@types/react-dom': ^16.8 || ^17.0 || ^18.0
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+      react-native: '>=0.59'
+      redux: ^4
     peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
       react-dom:
         optional: true
       react-native:
         optional: true
+      redux:
+        optional: true
     dependencies:
       '@babel/runtime': 7.17.9
-      '@types/react-redux': 7.1.23
+      '@types/hoist-non-react-statics': 3.3.1
+      '@types/react': 17.0.44
+      '@types/react-dom': 17.0.15
+      '@types/use-sync-external-store': 0.0.3
       hoist-non-react-statics: 3.3.2
-      loose-envify: 1.4.0
-      prop-types: 15.8.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-is: 17.0.2
+      react-is: 18.0.0
+      redux: 4.2.0
+      use-sync-external-store: 1.0.0_react@17.0.2
     dev: false
 
   /react-refresh/0.11.0:
@@ -14632,7 +14658,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /react-router-dom/6.2.2_react-dom@17.0.2+react@17.0.2:
+  /react-router-dom/6.2.2_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-AtYEsAST7bDD4dLSQHDnk/qxWLJdad5t1HFa1qJyUrCeGgEuCSw0VB/27ARbF9Fi/W5598ujvJOm3ujUCVzuYQ==}
     peerDependencies:
       react: '>=16.8'
@@ -14713,7 +14739,7 @@ packages:
       scheduler: 0.20.2
     dev: true
 
-  /react-textarea-autosize/8.3.3_c8e45b4eb687790dba17b4e1c4b4273f:
+  /react-textarea-autosize/8.3.3_zdsfwtvwq54q3oqxwtq4jnbhh4:
     resolution: {integrity: sha512-2XlHXK2TDxS6vbQaoPbMOfQ8GK7+irc2fVK6QFIcC8GOnH3zI/v481n+j1L0WaPVvKxwesnY93fEfH++sus2rQ==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -14722,12 +14748,12 @@ packages:
       '@babel/runtime': 7.17.9
       react: 17.0.2
       use-composed-ref: 1.2.1_react@17.0.2
-      use-latest: 1.2.0_c8e45b4eb687790dba17b4e1c4b4273f
+      use-latest: 1.2.0_zdsfwtvwq54q3oqxwtq4jnbhh4
     transitivePeerDependencies:
       - '@types/react'
     dev: true
 
-  /react-virtualized/9.22.3_react-dom@17.0.2+react@17.0.2:
+  /react-virtualized/9.22.3_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-MKovKMxWTcwPSxE1kK1HcheQTWfuCxAuBoSTf2gwyMM21NdX/PXUhnoP8Uc5dRKd+nKm8v41R36OellhdCpkrw==}
     peerDependencies:
       react: ^15.3.0 || ^16.0.0-alpha
@@ -14743,7 +14769,7 @@ packages:
       react-lifecycles-compat: 3.0.4
     dev: true
 
-  /react-window/1.8.6_react-dom@17.0.2+react@17.0.2:
+  /react-window/1.8.6_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-8VwEEYyjz6DCnGBsd+MgkD0KJ2/OXFULyDtorIiTz+QzwoP94tBoA7CnbtyXMm+cCeAUER5KJcPtWl9cpKbOBg==}
     engines: {node: '>8.0.0'}
     peerDependencies:
@@ -14890,8 +14916,8 @@ packages:
       strip-indent: 3.0.0
     dev: true
 
-  /redux/4.1.2:
-    resolution: {integrity: sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==}
+  /redux/4.2.0:
+    resolution: {integrity: sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==}
     dependencies:
       '@babel/runtime': 7.17.9
 
@@ -15286,7 +15312,7 @@ packages:
     engines: {node: '>=0.10'}
     dev: true
 
-  /rollup-plugin-dts/4.2.1_rollup@2.70.1+typescript@4.6.3:
+  /rollup-plugin-dts/4.2.1_3zpigpz7crs5s43nhxirf6uitu:
     resolution: {integrity: sha512-eaxQZNUJ5iQcxNGlpJ1CUgG4OSVqWjDZ3nNSWBIoGrpcote2aNphSe1RJOaSYkb8dwn3o+rYm1vvld/5z3EGSQ==}
     engines: {node: '>=v12.22.11'}
     peerDependencies:
@@ -15925,25 +15951,25 @@ packages:
     resolution: {integrity: sha512-iJtHSGmNgAUx0b/MCS6ASGxb//hGrHHRgzvN+K5bvkBTN7A9RTpPSf1WSp+nPGvWCJ1jRnvY7MKnuqfoi3OEqg==}
     dev: true
 
-  /storybook-addon-performance/0.16.1_b49bddbe4b905ced4713cb857cca91fa:
+  /storybook-addon-performance/0.16.1_wsn53pslsboo2rytzocxzsur7i:
     resolution: {integrity: sha512-hDMRXvZljwBXYKrNegB9+LvT1b0ZQlkvTEDqq4gbMovQcD9yR0mka1eDuhwZfzxcgY1PrhkN3EhNxLybA/ql9Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@storybook/addons': 6.4.19_react-dom@17.0.2+react@17.0.2
-      '@storybook/api': 6.4.19_react-dom@17.0.2+react@17.0.2
+      '@storybook/addons': 6.4.19_sfoxds7t5ydpegc3knd667wn6m
+      '@storybook/api': 6.4.19_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/channels': 6.4.19
-      '@storybook/components': 6.4.19_b49bddbe4b905ced4713cb857cca91fa
+      '@storybook/components': 6.4.19_wsn53pslsboo2rytzocxzsur7i
       '@storybook/core-events': 6.4.19
-      '@storybook/theming': 6.4.19_react-dom@17.0.2+react@17.0.2
+      '@storybook/theming': 6.4.19_sfoxds7t5ydpegc3knd667wn6m
       '@testing-library/dom': 7.31.2
       '@testing-library/jest-dom': 5.16.2
-      '@xstate/react': 1.6.3_7ce6a90b9093193255e12b5a0fae8c89
+      '@xstate/react': 1.6.3_pttksc4qsmmtevpbfnna7lumre
       gzip-js: 0.3.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      styled-components: 5.3.5_react-dom@17.0.2+react@17.0.2
+      styled-components: 5.3.5_sfoxds7t5ydpegc3knd667wn6m
       tiny-invariant: 1.2.0
       xstate: 4.30.6
     transitivePeerDependencies:
@@ -16199,7 +16225,7 @@ packages:
       inline-style-parser: 0.1.1
     dev: true
 
-  /styled-components/5.3.5_react-dom@17.0.2+react@17.0.2:
+  /styled-components/5.3.5_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-ndETJ9RKaaL6q41B69WudeqLzOpY1A/ET/glXkNZ2T7dPjPqpPCXXQjDFYZWwNnE5co0wX+gTCqx9mfxTmSIPg==}
     engines: {node: '>=10'}
     requiresBuild: true
@@ -16714,7 +16740,7 @@ packages:
     engines: {node: '>=6.10'}
     dev: true
 
-  /ts-jest/27.1.4_e5fb0852f9419ae84240799a2f4ee178:
+  /ts-jest/27.1.4_4x5qquxzignoqqsapgnc6txbpa:
     resolution: {integrity: sha512-qjkZlVPWVctAezwsOD1OPzbZ+k7zA5z3oxII4dGdZo5ggX/PL7kvwTM0pXTr10fAtbiVpJaL3bWd502zAhpgSQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     hasBin: true
@@ -16750,7 +16776,7 @@ packages:
       yargs-parser: 20.2.9
     dev: true
 
-  /ts-node/10.7.0_ddaac8e123aeb260f586984cee874848:
+  /ts-node/10.7.0_3wvmryjdv2zgb5mgtbgo5b2ija:
     resolution: {integrity: sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==}
     hasBin: true
     peerDependencies:
@@ -17136,7 +17162,7 @@ packages:
     resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
     dev: true
 
-  /url-loader/4.1.1_file-loader@6.2.0+webpack@4.46.0:
+  /url-loader/4.1.1_lit45vopotvaqup7lrvlnvtxwy:
     resolution: {integrity: sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -17175,7 +17201,7 @@ packages:
       react: 17.0.2
     dev: true
 
-  /use-isomorphic-layout-effect/1.1.1_c8e45b4eb687790dba17b4e1c4b4273f:
+  /use-isomorphic-layout-effect/1.1.1_zdsfwtvwq54q3oqxwtq4jnbhh4:
     resolution: {integrity: sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==}
     peerDependencies:
       '@types/react': '*'
@@ -17188,7 +17214,7 @@ packages:
       react: 17.0.2
     dev: true
 
-  /use-latest/1.2.0_c8e45b4eb687790dba17b4e1c4b4273f:
+  /use-latest/1.2.0_zdsfwtvwq54q3oqxwtq4jnbhh4:
     resolution: {integrity: sha512-d2TEuG6nSLKQLAfW3By8mKr8HurOlTkul0sOpxbClIv4SQ4iOd7BYr7VIzdbktUCnv7dua/60xzd8igMU6jmyw==}
     peerDependencies:
       '@types/react': '*'
@@ -17199,7 +17225,7 @@ packages:
     dependencies:
       '@types/react': 17.0.44
       react: 17.0.2
-      use-isomorphic-layout-effect: 1.1.1_c8e45b4eb687790dba17b4e1c4b4273f
+      use-isomorphic-layout-effect: 1.1.1_zdsfwtvwq54q3oqxwtq4jnbhh4
     dev: true
 
   /use-memo-one/1.1.2_react@17.0.2:
@@ -17218,6 +17244,14 @@ packages:
       object-assign: 4.1.1
       react: 17.0.2
     dev: true
+
+  /use-sync-external-store/1.0.0_react@17.0.2:
+    resolution: {integrity: sha512-AFVsxg5GkFg8GDcxnl+Z0lMAz9rE8DGJCc28qnBuQF7lac57B5smLcT37aXpXIIPz75rW4g3eXHPjhHwdGskOw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0-rc
+    dependencies:
+      react: 17.0.2
+    dev: false
 
   /use/3.1.1:
     resolution: {integrity: sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==}

--- a/src/view/draggable/connected-draggable.ts
+++ b/src/view/draggable/connected-draggable.ts
@@ -380,10 +380,7 @@ const ConnectedDraggable = connect(
   {
     // Using our own context for the store to avoid clashing with consumers
     context: StoreContext as any,
-    // Default value, but being really clear
-    pure: true,
     // When pure, compares the result of mapStateToProps to its previous value.
-    // Default value: shallowEqual
     // Switching to a strictEqual as we return a memoized object on changes
     areStatePropsEqual: isStrictEqual,
   },

--- a/src/view/draggable/connected-draggable.ts
+++ b/src/view/draggable/connected-draggable.ts
@@ -380,7 +380,7 @@ const ConnectedDraggable = connect(
   {
     // Using our own context for the store to avoid clashing with consumers
     context: StoreContext as any,
-    // When pure, compares the result of mapStateToProps to its previous value.
+    // Default value: shallowEqual
     // Switching to a strictEqual as we return a memoized object on changes
     areStatePropsEqual: isStrictEqual,
   },

--- a/src/view/droppable/connected-droppable.ts
+++ b/src/view/droppable/connected-droppable.ts
@@ -266,9 +266,6 @@ const ConnectedDroppable = connect(
   {
     // Ensuring our context does not clash with consumers
     context: StoreContext as any,
-    // pure: true is default value, but being really clear
-    pure: true,
-    // When pure, compares the result of mapStateToProps to its previous value.
     // Default value: shallowEqual
     // Switching to a strictEqual as we return a memoized object on changes
     areStatePropsEqual: isStrictEqual,


### PR DESCRIPTION
First of all, thanks for maintaining this package! 

When upgrading my app to react-redux to v8 i ran into the following error.

The `pure` property has been removed in react-redux v8 and will raise the error:
```'The `pure` option has been removed. `connect` is now always a "pure/memoized" component' ```

This PR is an intend to fix this issue when upgrading the react-redux and redux dependencies.