### PR TITLE
[react-redux] remove pure option

### DIFF
--- a/src/view/draggable/connected-draggable.ts
+++ b/src/view/draggable/connected-draggable.ts
@@ -380,8 +380,6 @@ const ConnectedDraggable = connect(
   {
     // Using our own context for the store to avoid clashing with consumers
     context: StoreContext as any,
-    // Default value, but being really clear
-    pure: true,
     // When pure, compares the result of mapStateToProps to its previous value.
     // Default value: shallowEqual
     // Switching to a strictEqual as we return a memoized object on changes

--- a/src/view/droppable/connected-droppable.ts
+++ b/src/view/droppable/connected-droppable.ts
@@ -266,8 +266,6 @@ const ConnectedDroppable = connect(
   {
     // Ensuring our context does not clash with consumers
     context: StoreContext as any,
-    // pure: true is default value, but being really clear
-    pure: true,
     // When pure, compares the result of mapStateToProps to its previous value.
     // Default value: shallowEqual
     // Switching to a strictEqual as we return a memoized object on changes


### PR DESCRIPTION
in react-redux v8, pure option has disappears
If we use @react-forked/dnd by forcing the version of react-redux to 8 it crashes just because of the pure option

In v7 , pure option it is by default true so it is useless to re-define it.

This PR let people migrate to react 18 / react-redux v8 without any crash temporary waiting for the official migration.