### PR TITLE
feat(browserslist): drop ie support and tweak a bit the config

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,8 +1,12 @@
-ie >= 11
-last 1 Edge version
-last 1 Firefox version
-last 1 Chrome version
-last 1 Safari version
-last 1 iOS version
-last 1 Android version
-last 1 ChromeAndroid version
+# These browsers account for 89.03% of all users globally
+last 5 versions
+not ios_saf < 15
+not safari < 15
+not samsung < 17
+not and_qq > 0
+not and_uc > 0
+not baidu > 0
+not ie > 0
+not kaios > 0
+not op_mob > 0
+not dead

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,25 +1,25 @@
 {
   "dnd.js": {
-    "bundled": 340503,
-    "minified": 125035,
-    "gzipped": 37311
+    "bundled": 311009,
+    "minified": 118887,
+    "gzipped": 36435
   },
   "dnd.min.js": {
-    "bundled": 302346,
-    "minified": 107277,
-    "gzipped": 30915
+    "bundled": 273188,
+    "minified": 101163,
+    "gzipped": 30032
   },
   "dnd.esm.js": {
-    "bundled": 242968,
-    "minified": 126368,
-    "gzipped": 32917,
+    "bundled": 215667,
+    "minified": 120659,
+    "gzipped": 32350,
     "treeshaked": {
       "rollup": {
-        "code": 21062,
-        "import_statements": 577
+        "code": 18507,
+        "import_statements": 456
       },
       "webpack": {
-        "code": 24501
+        "code": 21728
       }
     }
   }

--- a/docs/about/browser-support.md
+++ b/docs/about/browser-support.md
@@ -1,19 +1,17 @@
 # Browser support 🌍
 
-This library supports the standard [Atlassian supported browsers](https://confluence.atlassian.com/cloud/supported-browsers-744721663.html) for desktop:
-
-| Desktop                              | Version                                              |
-| ------------------------------------ | ---------------------------------------------------- |
-| Microsoft Internet Explorer(Windows) | Version 11                                           |
-| Microsoft Edge                       | Latest stable version supported                      |
-| Mozilla Firefox (all platforms)      | Latest stable version supported                      |
-| Google Chrome (Windows and Mac)      | Latest stable version supported                      |
-| Safari (Mac)                         | Latest stable version on latest OS release supported |
+| Desktop                              | Version                                                 |
+| ------------------------------------ | ------------------------------------------------------- |
+| Microsoft Edge                       | Latest 5 stable versions supported                      |
+| Mozilla Firefox (all platforms)      | Latest 5 stable versions supported                      |
+| Google Chrome (Windows and Mac)      | Latest 5 stable versions supported                      |
+| Safari (Mac)                         | Latest 5 stable versions on latest OS release supported |
 
 | Mobile                   | Version                                                   |
 | ------------------------ | --------------------------------------------------------- |
 | Chrome (Android and iOS) | Latest stable version supported                           |
 | Mobile Safari (iOS)      | Latest stable version supported                           |
-| Android (Android)        | The default browser on Android 4.0.3 (Ice Cream Sandwich) |
+
+_Internet Explorer 11 is no longer supported._
 
 [← Back to documentation](/README.md#documentation-)


### PR DESCRIPTION
```cmd
$ browserslist --coverage
These browsers account for 89.03% of all users globally

$ browserslist 
and_chr 104
and_ff 101
android 104
chrome 104
chrome 103
chrome 102
chrome 101
chrome 100
edge 104
edge 103
edge 102
edge 101
edge 100
firefox 103
firefox 102
firefox 101
firefox 100
firefox 99
ios_saf 15.5
ios_saf 15.4
ios_saf 15.2-15.3
ios_saf 15.0-15.1
op_mini all
opera 89
opera 88
opera 87
opera 86
opera 85
safari 15.6
safari 15.5
safari 15.4
safari 15.2-15.3
safari 15.1
samsung 18.0
samsung 17.0

```