### PR TITLE
✨ Quality: Add window edge restriction for dragging elements

### DIFF
--- a/src/view/draggable/get-style.ts
+++ b/src/view/draggable/get-style.ts
@@ -1,6 +1,7 @@
 import type { BoxModel } from 'css-box-model';
 import { combine, transforms, transitions } from '../../animation';
 import type { DraggableDimension } from '../../types';
+import getViewport from '../window/get-viewport';
 import type {
   DraggingStyle,
   NotDraggingStyle,
@@ -52,7 +53,18 @@ const getShouldDraggingAnimate = (dragging: DraggingMapProps): boolean => {
 function getDraggingStyle(dragging: DraggingMapProps): DraggingStyle {
   const dimension: DraggableDimension = dragging.dimension;
   const box: BoxModel = dimension.client;
-  const { offset, combineWith, dropping } = dragging;
+  let { offset, combineWith, dropping } = dragging;
+
+  if (dragging.restrictToWindowEdges) {
+    const viewport = getViewport();
+    const maxX: number = viewport.width - dimension.borderBox.width;
+    const maxY: number = viewport.height - dimension.borderBox.height;
+
+    offset = {
+      x: Math.max(0, Math.min(offset.x, maxX)),
+      y: Math.max(0, Math.min(offset.y, maxY)),
+    };
+  }
 
   const isCombining = Boolean(combineWith);
 


### PR DESCRIPTION
✨ Code Quality

This file calculates the drag styles for draggable elements. We need to modify the dragging style calculation to constrain the drag position within the window boundaries when `restrictToWindowEdges` prop is enabled.

Changes:
- `src/view/draggable/get-style.ts` (modified)

Import viewport utilities and modify `getDraggingStyle` to clamp the offset based on the draggable's dimensions vs viewport dimensions. Use `getViewport` from `src/view/window/get-viewport` and the draggable's `borderBox` to calculate maximum allowed offsets.

Closes #925